### PR TITLE
Add dependency for restoring packages before trying to find Microsoft.NETCore.DotNetAppHost package.

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -77,7 +77,7 @@
     </MSBuild>
   </Target>
 
-  <Target Name="PublishAppHostTemplate">
+  <Target Name="PublishAppHostTemplate" DependsOnTargets="RunResolvePackageDependencies">
 
     <PropertyGroup>
       <NETCoreDotNetAppHostPackageName>Microsoft.NETCore.DotNetAppHost</NETCoreDotNetAppHostPackageName>


### PR DESCRIPTION
This appears to be a difference between the 2.2.0-preview SDK currently being used in core-sdk and the 2.1.401-preview SDK currently being used in source-build.  In the 2.2.0 SDK, this target happens to run before the resolved package list is used, but in the 2.1.401 it is not, so I added the explicit dependency (doesn't affect anything in the 2.2.0 SDK).