### PR TITLE
Publish versions to build-info/dotnet/core-sdk

### DIFF
--- a/build_projects/dotnet-cli-build/UpdateVersionsRepo.cs
+++ b/build_projects/dotnet-cli-build/UpdateVersionsRepo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public override bool Execute()
         {
-            string versionsRepoPath = $"build-info/dotnet/cli/{BranchName}";
+            string versionsRepoPath = $"build-info/dotnet/core-sdk/{BranchName}";
 
             GitHubAuth auth = new GitHubAuth(GitHubPassword);
             GitHubVersionsRepoUpdater repoUpdater = new GitHubVersionsRepoUpdater(auth);


### PR DESCRIPTION
1st part of https://github.com/dotnet/core-eng/issues/3974

I don't know of any clean way to validate this change outside of actually committing the change and checking CI build results / changes to the versions repo. =(

PTAL @dagood @joshfree 