### PR TITLE
Fix dependency name showing twice in auto-PR title

### DIFF
--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -26,12 +26,12 @@ namespace Microsoft.DotNet.Scripts
 
             List<BuildInfo> buildInfos = new List<BuildInfo>(s_config.VersionFragments.Select<KeyValuePair<string, string>, BuildInfo>(fragment => 
                     GetBuildInfo(fragment.Key, fragment.Value, fetchLatestReleaseFile: false)));
-            IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
+            IEnumerable<IDependencyUpdater> updaters = GetUpdaters().ToArray();
             var dependencyBuildInfos = buildInfos.Select(buildInfo =>
                 new BuildDependencyInfo(
                     buildInfo,
                     upgradeStableVersions: true,
-                    disabledPackages: Enumerable.Empty<string>()));
+                    disabledPackages: Enumerable.Empty<string>())).ToArray();
             DependencyUpdateResults updateResults = DependencyUpdateUtils.Update(updaters, dependencyBuildInfos);
 
             if (!onlyUpdate && updateResults.ChangesDetected())


### PR DESCRIPTION
I recently figured out why this happens:

"Update **coresetup, coresetup** to preview1-26813-02, preview1-26813-02, respectively (master)" https://github.com/dotnet/core-sdk/pull/48

It's a VersionTools issue triggered by passing in an IEnumerable that generates new instances each time it's called: https://github.com/dotnet/buildtools/issues/2122.

Calling `.ToArray()` is a simple workaround, so I figured I'd submit a quick PR.