### PR TITLE
Add bundled FrameworkReferences

### DIFF
--- a/build/AzureInfo.props
+++ b/build/AzureInfo.props
@@ -14,6 +14,9 @@
     <CoreSetupBlobAccessToken Condition="'$(PB_AssetRootAccessTokenSuffix)' != ''">$(PB_AssetRootAccessTokenSuffix)</CoreSetupBlobAccessToken>
     <CoreSetupBlobAccessTokenParam Condition=" '$(CoreSetupBlobAccessToken)' != '' ">?$(CoreSetupBlobAccessToken)</CoreSetupBlobAccessTokenParam>
 
+    <DotnetExtensionsBlobRootUrl>$(PB_AssetRootUrl)</DotnetExtensionsBlobRootUrl>
+    <DotnetExtensionsBlobRootUrl Condition="'$(DotnetExtensionsBlobRootUrl)' == ''">https://dotnetcli.blob.core.windows.net/dotnet/</DotnetExtensionsBlobRootUrl>
+
     <!-- Values related to the upload of assets to blob storage -->
     <ArtifactCloudDropAccountName>$(ARTIFACT_STORAGE_ACCOUNT)</ArtifactCloudDropAccountName>
     <ArtifactCloudDropAccountName Condition="'$(ArtifactCloudDropAccountName)' == ''">dotnetcli</ArtifactCloudDropAccountName>

--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -23,6 +23,9 @@
     <DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime$(InstallerStartSuffix)-$(MicrosoftNETCoreAppPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
     <DownloadedSharedFrameworkInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(DownloadedSharedFrameworkInstallerFileName)</DownloadedSharedFrameworkInstallerFile>
 
+    <DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-extension-$(WinFormsAndWpfVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName>
+    <DownloadedWinFormsAndWpfSharedFrameworkInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFile>
+
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
     <SharedFrameworkRid>$(CoreSetupRid)</SharedFrameworkRid>
     <SharedFrameworkRid Condition=" '$(ProductMonikerRid)' == 'linux-musl-x64' ">$(ProductMonikerRid)</SharedFrameworkRid>
@@ -53,7 +56,7 @@
   <PropertyGroup>
     <CoreSetupRootUrl>$(CoreSetupBlobRootUrl)Runtime/</CoreSetupRootUrl>
     <AspNetCoreSharedFxRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/Runtime/</AspNetCoreSharedFxRootUrl>
-    <WinFormsAndWpfSharedFxRootUrl>$(CoreSetupBlobRootUrl)dotnet-extensions/</WinFormsAndWpfSharedFxRootUrl>
+    <WinFormsAndWpfSharedFxRootUrl>$(DotnetExtensionsBlobRootUrl)dotnet-extensions/</WinFormsAndWpfSharedFxRootUrl>
     <CoreSetupDownloadDirectory>$(IntermediateDirectory)/coreSetupDownload/$(MicrosoftNETCoreAppPackageVersion)</CoreSetupDownloadDirectory>
     <CombinedSharedHostAndFrameworkArchive>$(CoreSetupDownloadDirectory)/combinedSharedHostAndFrameworkArchive$(ArchiveExtension)</CombinedSharedHostAndFrameworkArchive>
   </PropertyGroup>
@@ -124,6 +127,13 @@
       <Url>$(WinFormsAndWpfSharedFxRootUrl)$(WinFormsAndWpfVersion)/$(WinFormsAndWpfSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
       <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFile)</DownloadFileName>
       <ExtractDestination>$(WinFormsAndWpfSharedFxPublishDirectory)/shared</ExtractDestination>
+    </_DownloadAndExtractItem>
+
+    <_DownloadAndExtractItem Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
+                         Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+      <Url>$(WinFormsAndWpfSharedFxRootUrl)$(WinFormsAndWpfVersion)/$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)$(CoreSetupBlobAccessTokenParam)</Url>
+      <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFile)</DownloadFileName>
+      <ExtractDestination></ExtractDestination>
     </_DownloadAndExtractItem>
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -39,7 +39,7 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
-    <WinFormsAndWpfVersion>3.0.0-alpha-26808-1</WinFormsAndWpfVersion>
+    <WinFormsAndWpfVersion>3.0.0-alpha-26823-9</WinFormsAndWpfVersion>
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ToolsetVersion>3.0.100-alpha1-009349</ToolsetVersion>
+    <ToolsetVersion>3.0.100-alpha1-009351</ToolsetVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -105,6 +105,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
 
+    <AddDotnetfeedProjectSource Condition="'%24(AddDotnetfeedProjectSource)' == ''">%24(_NETCoreSdkIsPreview)</AddDotnetfeedProjectSource>
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources);https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreAdditionalProjectSources>
+
     <!-- Default patch versions for each minor version of ASP.NET Core -->
     <DefaultPatchVersionForAspNetCoreAll2_1>$(_DefaultPatchVersionForAspNetCoreAll2_1)</DefaultPatchVersionForAspNetCoreAll2_1>
     <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -118,6 +118,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
     <LatestPatchVersionForNetCore2_1 Condition="'%24(LatestPatchVersionForNetCore2_1)' == ''">2.1.2</LatestPatchVersionForNetCore2_1>
   </PropertyGroup>
+  <ItemGroup>
+    <KnownFrameworkReference Include="Microsoft.Windows.UI"
+                              RuntimeFrameworkName="Microsoft.Private.WPF"
+                              DefaultRuntimeFrameworkVersion="$(WinFormsAndWpfVersion)"
+                              LatestRuntimeFrameworkVersion="$(WinFormsAndWpfVersion)"
+                              TargetingPackName="Microsoft.Private.WPF"
+                              TargetingPackVersion="$(WinFormsAndWpfVersion)"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.AspNetCore"
+                              RuntimeFrameworkName="Microsoft.AspNetCore.App"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              TargetingPackName="Microsoft.AspNetCore.App"
+                              TargetingPackVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              />
+  </ItemGroup>
 </Project>
 ]]>
     </BundledVersionsPropsContent>

--- a/build/Prepare.targets
+++ b/build/Prepare.targets
@@ -40,9 +40,15 @@
       <OverwriteExtractionDestination Condition="'$(OverwriteExtractionDestination)' == ''">True</OverwriteExtractionDestination>
     </PropertyGroup>
 
-    <DownloadFile Condition=" '@(_DownloadAndExtractItem)' != '' "
+
+    <DownloadFile Condition=" '@(_DownloadAndExtractItem)' != '' And '%(_DownloadAndExtractItem.Local)' != 'true'"
                   Uri="%(_DownloadAndExtractItem.Url)"
                   DestinationPath="%(_DownloadAndExtractItem.DownloadFileName)" />
+
+    <Copy Condition=" '@(_DownloadAndExtractItem)' != '' And '%(_DownloadAndExtractItem.Local)' == 'true'"
+          SourceFiles="%(_DownloadAndExtractItem.Url)"
+          DestinationFiles="%(_DownloadAndExtractItem.DownloadFileName)" />
+                  
 
     <ZipFileExtractToDirectory Condition=" '%(_DownloadAndExtractItem.ExtractDestination)' != '' AND $([System.String]::new('%(_DownloadAndExtractItem.DownloadFileName)').EndsWith('.zip')) "
                                SourceArchive="%(_DownloadAndExtractItem.DownloadFileName)"

--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -155,6 +155,7 @@
                       '$(DownloadedSharedFrameworkInstallerFile)'
                       '$(DownloadedHostFxrInstallerFile)'
                       '$(DownloadedSharedHostInstallerFile)'
+                      '$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFile)'
                       '$(CombinedFrameworkSdkHostInstallerFile)'
                       '$(WixRoot)'
                       '$(SdkBrandName)'

--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -38,6 +38,9 @@
       <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
+      <MsiPackage SourceFile="$(var.WinFormsAndWpfMsiSourcePath)">
+        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
+      </MsiPackage>
        <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />

--- a/packaging/windows/clisdk/generatebundle.ps1
+++ b/packaging/windows/clisdk/generatebundle.ps1
@@ -7,6 +7,7 @@ param(
     [Parameter(Mandatory=$true)][string]$SharedFxMSIFile,
     [Parameter(Mandatory=$true)][string]$HostFxrMSIFile,
     [Parameter(Mandatory=$true)][string]$SharedHostMSIFile,
+    [Parameter(Mandatory=$true)][string]$WinFormsAndWpfMSIFile,
     [Parameter(Mandatory=$true)][string]$DotnetBundleOutput,
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$ProductMoniker,
@@ -42,6 +43,7 @@ function RunCandleForBundle
         -dSharedFXMsiSourcePath="$SharedFxMSIFile" `
         -dHostFXRMsiSourcePath="$HostFxrMSIFile" `
         -dSharedHostMsiSourcePath="$SharedHostMSIFile" `
+        -dWinFormsAndWpfMsiSourcePath="$WinFormsAndWpfMSIFile" `
         -dAdditionalSharedFXMsiSourcePath="$AdditionalSharedFxMSIFile" `
         -dAdditionalHostFXRMsiSourcePath="$AdditionalHostFxrMSIFile" `
         -dAdditionalSharedHostMsiSourcePath="$AdditionalSharedHostMSIFile" `


### PR DESCRIPTION
- Update Winforms / WPF shared framework
- Add blob feed as additional NuGet feed if SDK is preview
  - This will make it easier to use the SDK until we replace the lzma with targeting packs laid out by the installer, and everything is "coherent"
- Add KnownFrameworkReference items for `Microsoft.Windows.UI` and `Microsoft.AspNetCore`.  Whether these are the final names or not is still TBD
- Add hook to use locally built copy of the toolset instead of downloading it

I also intend to insert the SDK changes supporting `FrameworkReference` (https://github.com/dotnet/sdk/pull/2486) in this PR, but that needs to flow through the toolset first so it will come a bit later.