### PR TITLE
Add property for SDK runtime identifier.

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -103,6 +103,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
     @(BundledVersionsVariable->'<%(Identity)>%(Value)</%(Identity)>', '%0A    ')
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
+    <NETCoreSdkRuntimeIdentifier>$(CoreSetupRid)</NETCoreSdkRuntimeIdentifier>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
 
     <AddDotnetfeedProjectSource Condition="'%24(AddDotnetfeedProjectSource)' == ''">%24(_NETCoreSdkIsPreview)</AddDotnetfeedProjectSource>


### PR DESCRIPTION
Adding `NETCoreSdkRuntimeIdentifier` which is set to the RID the SDK is
building for.

This property enables us to restore assets for the SDK's RID to enable
generating an apphost by default.
