### PR TITLE
Enable CrossGen during publishing on ARM

### DIFF
--- a/build/CrossGen.props
+++ b/build/CrossGen.props
@@ -2,9 +2,13 @@
   <PropertyGroup>
     <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
     <_crossDir Condition="'$(Architecture)' == 'arm64'">/x64_arm64</_crossDir>
+    <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
+    <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">/x64_arm</_crossDir>
     <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/tools$(_crossDir)/crossgen$(ExeExtension)</CrossgenPath>
-    <LibCLRJitRid Condition="'$(Architecture)' != 'arm64'">$(SharedFrameworkRid)</LibCLRJitRid>
+    <LibCLRJitRid Condition="!$(Architecture.StartsWith('arm'))">$(SharedFrameworkRid)</LibCLRJitRid>
     <LibCLRJitRid Condition="'$(Architecture)' == 'arm64'">x64_arm64</LibCLRJitRid>
+    <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86_arm</LibCLRJitRid>
+    <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">x64_arm</LibCLRJitRid>
     <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/runtimes/$(LibCLRJitRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
     <SharedFrameworkNameVersionPath>$(OutputDirectory)/shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppPackageVersion)</SharedFrameworkNameVersionPath>
   </PropertyGroup>

--- a/build_projects/dotnet-cli-build/Crossgen.cs
+++ b/build_projects/dotnet-cli-build/Crossgen.cs
@@ -52,7 +52,9 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            TempOutputPath = Path.GetTempFileName();
+            string tempDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirPath);
+            TempOutputPath = Path.Combine(tempDirPath, Path.GetFileName(DestinationPath));
 
             var toolResult = base.Execute();
 
@@ -65,6 +67,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 File.Delete(TempOutputPath);
             }
+            Directory.Delete(tempDirPath);
 
             if (toolResult && CreateSymbols)
             {

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -123,7 +123,7 @@
   </Target>
 
   <Target Name="CrossgenPublishDir"
-          Condition=" '$(DISABLE_CROSSGEN)' == '' And !$(Architecture.StartsWith('arm')) "
+          Condition="'$(DISABLE_CROSSGEN)' == ''"
           AfterTargets="PublishSdks">
     <ItemGroup>
       <RoslynFiles Include="$(PublishDir)Roslyn\bincore\**\*" />


### PR DESCRIPTION
Both coreclr (https://github.com/dotnet/coreclr/pull/19960) and core-setup (https://github.com/dotnet/core-setup/pull/4621) use Hostx64/arm CrossGen to produce their native images during official build. This PR do the same for the rest of Core SDK (Roslyn FSharp and the "remaining" assemblies as defined in src/redist/redist.csproj) **and** also enables *"CrossgenPublishDir"* MSBuild target on both ARM/ARM64.

I also noticed that native images produced by core-sdk/build.sh are different from one run to another even though source assemblies were exactly the same. It turned out that CrossGen encodes the output file name in produced native image. To "stabilize" the CrossGen output I make the change in build_projects/dotnet-cli-build/Crossgen.cs to avoiding usage of random file name.

**Related issues:**
* https://github.com/dotnet/cli/issues/8870
* https://github.com/dotnet/cli/issues/8998

@livarcocc @RussKeldorph @eerhardt Please take a look.