### PR TITLE
Insert updated toolset

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ToolsetVersion>3.0.100-alpha1-009519</ToolsetVersion>
+    <ToolsetVersion>3.0.100-alpha1-009562</ToolsetVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -62,11 +62,11 @@
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="1.0"
                                DefaultVersion="1.0.5"
-                               LatestVersion="1.0.12" />
+                               LatestVersion="1.0.13" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="1.1"
                                DefaultVersion="1.1.2"
-                               LatestVersion="1.1.9" />
+                               LatestVersion="1.1.10" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.0"
                                DefaultVersion="2.0.0"

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -156,6 +156,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     
     <KnownFrameworkReference Include="Microsoft.DesktopUI"
+                              TargetFramework="netcoreapp3.0"
                               RuntimeFrameworkName="Microsoft.DesktopUI.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftDesktopUIPackageVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftDesktopUIPackageVersion)"
@@ -164,6 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore"
+                              TargetFramework="netcoreapp3.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -37,11 +37,16 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                     .Execute()
                     .Should().Pass();
 
-                new RunCommand()
-                    .WithWorkingDirectory(projectDirectory)
-                    .ExecuteWithCapturedOutput()
+                var runCommand = new RunCommand()
+                    .WithWorkingDirectory(projectDirectory);
+
+                //  Set DOTNET_ROOT as workaround for https://github.com/dotnet/cli/issues/10196
+                runCommand = runCommand.WithEnvironmentVariable(Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)",
+                    Path.GetDirectoryName(DotnetUnderTest.FullName));
+
+                runCommand.ExecuteWithCapturedOutput()
                     .Should().Pass()
-                         .And.HaveStdOutContaining("Hello World!");
+                    .And.HaveStdOutContaining("Hello World!");
 
                 var binDirectory = new DirectoryInfo(projectDirectory).Sub("bin");
                 binDirectory.Should().HaveFilesMatching("*.dll", SearchOption.AllDirectories);


### PR DESCRIPTION
This should include the updated .NET SDK which includes the ASP.NET implicit version changes from the 2.2 branch (as well as other changes).

This does not yet re-enable the implicit version tests (dotnet/cli#10123), as there is still some work to do on those tests and we shouldn't block code flow on that.