### PR TITLE
Update toolset and Microsoft.DesktopUI.App to latest

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ToolsetVersion>3.0.100-preview-009701</ToolsetVersion>
+    <ToolsetVersion>3.0.100-preview-009703</ToolsetVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -38,7 +38,7 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
-    <MicrosoftDesktopUIPackageVersion>3.0.0-alpha-27030-3</MicrosoftDesktopUIPackageVersion>
+    <MicrosoftDesktopUIPackageVersion>3.0.0-alpha-27106-4</MicrosoftDesktopUIPackageVersion>
     <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftDesktopUIPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftDesktopUIPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
* Latest Microsoft.NET.Sdk.Wpf includes for custom controls failing to build when XAML properties require custom converters.
* Latest Microsft.DesktopUI.App builds against latest Microsoft.NETCore.App and fixes #134