### PR TITLE
Use `ProductMonikerRid` instead of `CoreSetupRid` for SDK RID.

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -135,7 +135,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
     @(BundledVersionsVariable->'<%(Identity)>%(Value)</%(Identity)>', '%0A    ')
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
-    <NETCoreSdkRuntimeIdentifier>$(CoreSetupRid)</NETCoreSdkRuntimeIdentifier>
+    <NETCoreSdkRuntimeIdentifier>$(ProductMonikerRid)</NETCoreSdkRuntimeIdentifier>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
 
     <AddDotnetfeedProjectSource Condition="'%24(AddDotnetfeedProjectSource)' == ''">%24(_NETCoreSdkIsPreview)</AddDotnetfeedProjectSource>


### PR DESCRIPTION
This commit changes `NETCoreSdkRuntimeIdentifier` to be based off of
`ProductMonikerRid` instead of `CoreSetupRid`.

`CoreSetupRid` is set to the host RID for the build, by default.  For most
architectures, this was fine.  However, for ARM/ARM64 builds, we cross-build,
so `CoreSetupRid` is actually x64 and not ARM/ARM64.

As a result, the default apphost being used isn't built for ARM so `dotnet run`
fails with an exec format error when trying to exec the apphost.

Instead, we should be using the RID of the product being built rather than the
host RID.

Fixes dotnet/cli#10291.
