### PR TITLE
Insert WindowsDesktop, and corresponding project templates

### DIFF
--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -23,7 +23,7 @@
     <DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime$(InstallerStartSuffix)-$(MicrosoftNETCoreAppPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
     <DownloadedSharedFrameworkInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(DownloadedSharedFrameworkInstallerFileName)</DownloadedSharedFrameworkInstallerFile>
 
-    <DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-extension-$(MicrosoftDesktopUIPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName>
+    <DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-extension-$(MicrosoftWindowsDesktopPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName>
     <DownloadedWinFormsAndWpfSharedFrameworkInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFile>
 
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
@@ -45,7 +45,7 @@
     <AspNetCoreSharedFxArchiveFileName>aspnetcore-runtime-internal-$(AspNetCoreVersion)-$(AspNetCoreSharedFxArchiveRid)$(ArchiveExtension)</AspNetCoreSharedFxArchiveFileName>
     <AspNetCoreSharedFxArchiveFile>$(PackagesDirectory)/$(AspNetCoreSharedFxArchiveFileName)</AspNetCoreSharedFxArchiveFile>
 
-    <WinFormsAndWpfSharedFxArchiveFileName>dotnet-extension-$(MicrosoftDesktopUIPackageVersion)-$(Architecture)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>
+    <WinFormsAndWpfSharedFxArchiveFileName>dotnet-extension-$(MicrosoftWindowsDesktopPackageVersion)-$(Architecture)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>
     <WinFormsAndWpfSharedFxArchiveFile>$(PackagesDirectory)/$(WinFormsAndWpfSharedFxArchiveFileName)</WinFormsAndWpfSharedFxArchiveFile>
 
     <!-- Used to detect if ASP.NET Core is built against the same version of Microsoft.NETCore.App. -->
@@ -124,14 +124,14 @@
   <ItemGroup Condition=" '$(IncludeWpfAndWinForms)' != 'false' ">
     <_DownloadAndExtractItem Include="WinFormsAndWpfSharedFxArchiveFile"
                              Condition="!Exists('$(WinFormsAndWpfSharedFxArchiveFile)')">
-      <Url>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftDesktopUIPackageVersion)/$(WinFormsAndWpfSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
+      <Url>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopPackageVersion)/$(WinFormsAndWpfSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
       <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFile)</DownloadFileName>
       <ExtractDestination>$(WinFormsAndWpfSharedFxPublishDirectory)/shared</ExtractDestination>
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
                          Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
-      <Url>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftDesktopUIPackageVersion)/$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)$(CoreSetupBlobAccessTokenParam)</Url>
+      <Url>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopPackageVersion)/$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)$(CoreSetupBlobAccessTokenParam)</Url>
       <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFile)</DownloadFileName>
       <ExtractDestination></ExtractDestination>
     </_DownloadAndExtractItem>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27113-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27114-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
   </PropertyGroup>
 
@@ -38,9 +38,9 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
-    <MicrosoftDesktopUIPackageVersion>3.0.0-alpha-27113-1</MicrosoftDesktopUIPackageVersion>
-    <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftDesktopUIPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftDesktopUIPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftWindowsDesktopPackageVersion>3.0.0-alpha-27115-10</MicrosoftWindowsDesktopPackageVersion>
+    <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -155,13 +155,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     @(ImplicitPackageVariable->'<ImplicitPackageReferenceVersion Include="%(Identity)" TargetFrameworkVersion="%(TargetFrameworkVersion)" DefaultVersion="%(DefaultVersion)" LatestVersion="%(LatestVersion)"/>', '%0A    ')
 
     
-    <KnownFrameworkReference Include="Microsoft.DesktopUI"
+    <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="netcoreapp3.0"
-                              RuntimeFrameworkName="Microsoft.DesktopUI.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftDesktopUIPackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftDesktopUIPackageVersion)"
-                              TargetingPackName="Microsoft.DesktopUI.App"
-                              TargetingPackVersion="$(MicrosoftDesktopUIPackageVersion)"
+                              RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopPackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopPackageVersion)"
+                              TargetingPackName="Microsoft.WindowsDesktop.App"
+                              TargetingPackVersion="$(MicrosoftWindowsDesktopPackageVersion)"
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"


### PR DESCRIPTION
Insert updated / renamed WindowsDesktop, and corresponding project templates.

NOTE: This changes the project file format for WPF and Windows Forms projects.  The project templates will now create projects that look like this:

## WPF

```xml
<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">

  <PropertyGroup>
    <OutputType>WinExe</OutputType>
    <TargetFramework>netcoreapp3.0</TargetFramework>
    <UseWPF>true</UseWPF>
  </PropertyGroup>

</Project>
```

## Windows Forms

```xml
<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">

  <PropertyGroup>
    <OutputType>WinExe</OutputType>
    <TargetFramework>netcoreapp3.0</TargetFramework>
    <UseWindowsForms>true</UseWindowsForms>
  </PropertyGroup>

</Project>
```