### PR TITLE
Unofficial support for freebsd

### DIFF
--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -8,6 +8,7 @@
     <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
     <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND
         ($(Rid.StartsWith('rhel.6'))
+        OR $(Rid.StartsWith('freebsd'))
         OR $(Rid.StartsWith('linux-musl'))
         OR $(Rid.StartsWith('fedora.27'))
         OR $(Rid.StartsWith('opensuse.42.3'))
@@ -16,6 +17,7 @@
 
     <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'linux-musl-x64' ">true</UsePortableLinuxSharedFramework>
     <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == ''
+        AND '$(Rid)' != 'freebsd-x64'
         AND '$(Rid)' != 'linux-x64'
         AND '$(Rid)' != 'rhel.6-x64'
         AND '$(Rid)' != 'linux-musl-x64'

--- a/build/BuildInfo.targets
+++ b/build/BuildInfo.targets
@@ -9,7 +9,7 @@
     </GetCurrentRuntimeInformation>
 
     <PropertyGroup>
-      <IsLinux Condition = " '$(HostOSName)' != 'win' AND '$(HostOSName)' != 'osx' ">True</IsLinux>
+      <IsLinux Condition = " '$(HostOSName)' != 'win' AND '$(HostOSName)' != 'osx' AND '$(HostOSName)' != 'freebsd'">True</IsLinux>
       <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' != 'True' ">$(HostOSName)</OSName>
       <OSPlatform Condition=" '$(OSPlatform)' == '' AND '$(IsLinux)' != 'True' ">$(HostOSPlatform)</OSPlatform>
       <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' == 'True' ">linux</OSName>

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
@@ -34,6 +34,14 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
         }
 
+        public static bool IsFreeBSD
+        {
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
+            }
+        }
+
         public static bool IsUbuntu
         {
             get
@@ -83,7 +91,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             get
             {
-                return IsLinux || IsOSX;
+                return IsLinux || IsOSX || IsFreeBSD;
             }
         }
 
@@ -124,6 +132,8 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                     return IsUbuntu;
                 case BuildPlatform.OSX:
                     return IsOSX;
+                case BuildPlatform.FreeBSD:
+                    return IsFreeBSD;
                 case BuildPlatform.CentOS:
                     return IsCentOS;
                 case BuildPlatform.RHEL:
@@ -181,6 +191,10 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             else if (IsOpenSuse)
             {
                 return BuildPlatform.OpenSuse;
+            }
+            else if (IsFreeBSD)
+            {
+                return BuildPlatform.FreeBSD;
             }
             else
             {

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         RHEL = 7,
         Debian = 8,
         Fedora = 9,
-        OpenSuse = 10
+        OpenSuse = 10,
+        FreeBSD = 11
     }
 }

--- a/scripts/cli-test-env.sh
+++ b/scripts/cli-test-env.sh
@@ -17,6 +17,8 @@ uname=$(uname)
 if [ "$(uname)" = "Darwin" ]
 then
   RID=osx-x64
+elif [ "$(uname)" = "FreeBSD" ]; then
+  RID=freebsd-x64
 else
   RID=linux-x64
 fi

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -182,6 +182,7 @@
     <PropertyGroup Condition="'$(CreateCrossgenSymbols)' == ''">
       <CreateCrossgenSymbols>true</CreateCrossgenSymbols>
       <CreateCrossgenSymbols Condition="'$(OSName)' == 'osx'">false</CreateCrossgenSymbols>
+      <CreateCrossgenSymbols Condition="'$(OSName)' == 'freebsd'">false</CreateCrossgenSymbols>
    </PropertyGroup>
 
     <Crossgen


### PR DESCRIPTION
With proposed change following command produces useable dotnet-sdk-3.0.100-preview-009756-freebsd-x64.tar.gz.

./run-build.sh --stage0 /tmp/XXX/ /p:HostRid=freebsd-x64  /p:IncludeAspNetCoreRuntime=false

 I only tested creating and running hello world app. 
Note that the HostRid is needed. Without it we default to freebsd.11-x64 and than we fail to download packages as we build everything else as portable. (without OS version)    