### PR TITLE
Update ASP.NET Core to 3.0.0-alpha1-10772

### DIFF
--- a/TestAssets/TestProjects/TestRazorApp/TestRazorApp.csproj
+++ b/TestAssets/TestProjects/TestRazorApp/TestRazorApp.csproj
@@ -2,10 +2,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
+++ b/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Target Name="WriteDefaultPatchVersionsFile" BeforeTargets="Restore">

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,15 +5,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftAspNetCoreAllPackageVersion>3.0.0-alpha1-10663</MicrosoftAspNetCoreAllPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <MicrosoftAspNetCoreMvcPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreMvcPackageVersion>
-    <DotnetEfPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</DotnetEfPackageVersion>
-    <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</DotnetDevCertsPackageVersion>
-    <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</DotnetSqlCachePackageVersion>
-    <DotnetUserSecretsPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</DotnetUserSecretsPackageVersion>
-    <DotnetWatchPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</DotnetWatchPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-alpha1-10772</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <DotnetEfPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetEfPackageVersion>
+    <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetDevCertsPackageVersion>
+    <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetSqlCachePackageVersion>
+    <DotnetUserSecretsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetUserSecretsPackageVersion>
+    <DotnetWatchPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetWatchPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,9 +5,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Dependencies from https://github.com/aspnet/EntityFrameworkCore -->
+    <DotnetEfPackageVersion>3.0.0-preview.18569.2</DotnetEfPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
     <MicrosoftAspNetCoreAppPackageVersion>3.0.0-alpha1-10772</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <DotnetEfPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetEfPackageVersion>
     <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetDevCertsPackageVersion>
     <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetSqlCachePackageVersion>
     <DotnetUserSecretsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetUserSecretsPackageVersion>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -29,21 +29,17 @@
       <_NETCoreAppPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</_NETCoreAppPackageVersion>
       <_NETStandardLibraryPackageVersion>@(_NETStandardLibraryPackageVersions->Distinct())</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>@(_NETCorePlatformsPackageVersions->Distinct())</_NETCorePlatformsPackageVersion>
-      <_AspNetCoreAllPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</_AspNetCoreAllPackageVersion>
       <_AspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</_AspNetCoreAppPackageVersion>
 
       <!-- Default aspnetcore patch versions, specified as a stabilized version -->
-      <_DefaultPatchVersionForAspNetCoreAll2_1>2.1.1</_DefaultPatchVersionForAspNetCoreAll2_1>
-      <_DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreAll2_1)</_DefaultPatchVersionForAspNetCoreApp2_1>
+      <_DefaultPatchVersionForAspNetCoreApp3_0>3.0.0</_DefaultPatchVersionForAspNetCoreApp3_0>
       <!-- If we are currently building a prerelease of the version that we intend to lock to, set the default version to the ingested version instead of the stabilized version. -->
-      <_DefaultPatchVersionForAspNetCoreAll2_1 Condition="$(_AspNetCoreAllPackageVersion.StartsWith('$(_DefaultPatchVersionForAspNetCoreAll2_1)-'))">$(_AspNetCoreAllPackageVersion)</_DefaultPatchVersionForAspNetCoreAll2_1>
-      <_DefaultPatchVersionForAspNetCoreApp2_1 Condition="$(_AspNetCoreAppPackageVersion.StartsWith('$(_DefaultPatchVersionForAspNetCoreApp2_1)-'))">$(_AspNetCoreAppPackageVersion)</_DefaultPatchVersionForAspNetCoreApp2_1>
+      <_DefaultPatchVersionForAspNetCoreApp3_0 Condition="$(_AspNetCoreAppPackageVersion.StartsWith('$(_DefaultPatchVersionForAspNetCoreApp3_0)-'))">$(_AspNetCoreAppPackageVersion)</_DefaultPatchVersionForAspNetCoreApp3_0>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
       <_NETStandardTargetFrameworkVersion>$(_NETStandardLibraryPackageVersion.Split('.')[0]).$(_NETStandardLibraryPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
-      <_AspNetCoreAllTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</_AspNetCoreAllTargetFrameworkVersion>
-      <_AspNetCoreAppTargetFrameworkVersion>$(_AspNetCoreAllTargetFrameworkVersion)</_AspNetCoreAppTargetFrameworkVersion>
+      <_AspNetCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</_AspNetCoreAppTargetFrameworkVersion>
 
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
     </PropertyGroup>
@@ -91,23 +87,8 @@
     </ItemGroup>
     
     <ItemGroup>
-      <BundledVersionsVariable Include="BundledAspNetCoreAllTargetFrameworkVersion" Value="$(_AspNetCoreAllTargetFrameworkVersion)" />
-      <BundledVersionsVariable Include="BundledAspNetCoreAllPackageVersion" Value="$(_AspNetCoreAllPackageVersion)" />
       <BundledVersionsVariable Include="BundledAspNetCoreAppTargetFrameworkVersion" Value="$(_AspNetCoreAppTargetFrameworkVersion)" />
       <BundledVersionsVariable Include="BundledAspNetCoreAppPackageVersion" Value="$(_AspNetCoreAppPackageVersion)" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' == 'false' ">
-      <!--
-        These properties indicate that the ASP.NET Core shared runtime is not bundled on this platform, so the SDK should not
-        treat these packages as the 'platform' base.
-
-        The bundled aspnet packages versions should still be set, however, so the default, version-less PackageReference
-        still works.
-        See also https://github.com/aspnet/Universe/pull/1130.
-      -->
-      <BundledVersionsVariable Include="_AspNetCoreAppSharedFxIsEnabled" Value="false" />
-      <BundledVersionsVariable Include="_AspNetCoreAllSharedFxIsEnabled" Value="false" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -142,8 +123,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources);https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreAdditionalProjectSources>
 
     <!-- Default patch versions for each minor version of ASP.NET Core -->
-    <DefaultPatchVersionForAspNetCoreAll2_1>$(_DefaultPatchVersionForAspNetCoreAll2_1)</DefaultPatchVersionForAspNetCoreAll2_1>
-    <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>
+    <DefaultPatchVersionForAspNetCoreAll2_1>2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
+    <DefaultPatchVersionForAspNetCoreApp2_1>2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
     <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.12</LatestPatchVersionForNetCore1_0>

--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -87,10 +87,9 @@ namespace Microsoft.DotNet.Scripts
 
             if (s_config.HasVersionFragment("aspnet"))
             {
-                yield return CreateRegexUpdater(dependencyVersionsPath, "MicrosoftAspNetCoreAllPackageVersion", "Microsoft.AspNetCore.All");
+                yield return CreateRegexUpdater(dependencyVersionsPath, "MicrosoftAspNetCoreAppPackageVersion", "Microsoft.AspNetCore.App");
                 yield return CreateRegexUpdater(dependencyVersionsPath, "DotnetEfPackageVersion", "dotnet-ef");
                 yield return CreateRegexUpdater(dependencyVersionsPath, "MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion", "Microsoft.AspNetCore.DeveloperCertificates.XPlat");
-                yield return CreateRegexUpdater(dependencyVersionsPath, "MicrosoftAspNetCoreMvcPackageVersion", "Microsoft.AspNetCore.Mvc");
                 yield return CreateRegexUpdater(dependencyVersionsPath, "DotnetDevCertsPackageVersion", "dotnet-dev-certs");
                 yield return CreateRegexUpdater(dependencyVersionsPath, "DotnetSqlCachePackageVersion", "dotnet-sql-cache");
                 yield return CreateRegexUpdater(dependencyVersionsPath, "DotnetUserSecretsPackageVersion", "dotnet-user-secrets");


### PR DESCRIPTION
This build of aspnet core depends on .NET Core 3.0.0-preview-27117-01. We'll likely have to update this again due to https://github.com/dotnet/core-setup/issues/4797, but opening this anyways to get started on inserting a new version of aspnet.

Notable changes since 3.0.0-alpha1-10663
* Templates rely on the implicit FrameworkReference in Microsoft.NET.Sdk.Web
* Refactored Microsoft.AspNetCore.App metapackage
* Dropped Microsoft.AspNetCore.All
* Microsoft.AspNetCore.App package is rid-split, just like Microsoft.NETCore.App
* EF Core versions separately from aspnetcore

cc @dsplaisted @livarcocc @Eilon @ajcvickers
