### PR TITLE
Fix 'websites.It' typo in macOS installer

### DIFF
--- a/packaging/osx/clisdk/resources/cs.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/cs.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/de.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/de.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/en.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/en.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/es.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/es.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/fr.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/fr.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/it.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/it.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/ja.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/ja.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/ko.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/ko.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/pl.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/pl.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/pt-br.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/pt-br.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/ru.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/ru.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/tr.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/tr.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/zh-hans.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/zh-hans.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>

--- a/packaging/osx/clisdk/resources/zh-hant.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/zh-hant.lproj/welcome.html
@@ -7,7 +7,7 @@
     <br>
     <div align="left" style="font-family: Helvetica;padding-left:10px">
         <h2>.NET Core SDK</h2>
-        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites.It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
+        <p>.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</p>
     </div>
     <div align="left" style="font-family: Helvetica">
         <h2 style="padding-left:10px">Learn more about .NET Core</h2>


### PR DESCRIPTION
The welcome page in the macOS installer for the .NET Core SDK
is missing a space. ("websites.It")

skip ci please
