### PR TITLE
Update aspnet to 18572-0018 and efcore to 18572.1

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,12 +6,12 @@
 
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/EntityFrameworkCore -->
-    <DotnetEfPackageVersion>3.0.0-preview.18569.2</DotnetEfPackageVersion>
+    <DotnetEfPackageVersion>3.0.0-preview.18572.1</DotnetEfPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-alpha1-10772</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview-18572-0018</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetDevCertsPackageVersion>
     <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetSqlCachePackageVersion>


### PR DESCRIPTION
This updates the bundled version of aspnetcore to 3.0.0-preview-18572-0018 and dotnet-ef to 3.0.0-preview.18572.1.

These should align with core-setup's 3.0.0-preview-27122-01 build.