### PR TITLE
Fix .binlog archiving

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -66,7 +66,7 @@ phases:
         SourceFolder: '$(Build.SourcesDirectory)'
         Contents: |
          msbuild.log
-         msbuild.mainbuild.binlog
+         msbuild.binlog
          msbuild.generatepropsfile.binlog
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
       continueOnError: true

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -113,6 +113,6 @@ if ($NoBuild)
 else
 {
     dotnet msbuild build.proj /bl:msbuild.generatepropsfile.binlog /p:Architecture=$Architecture /p:GeneratePropsFile=true /t:WriteDynamicPropsToStaticPropsFiles $ExtraParametersNoTargets
-    dotnet msbuild build.proj /bl:msbuild.mainbuild.binlog /m /v:normal /fl /flp:v=diag /bl /p:Architecture=$Architecture $ExtraParameters
+    dotnet msbuild build.proj /m /v:normal /fl /flp:v=diag /bl /p:Architecture=$Architecture $ExtraParameters
     if($LASTEXITCODE -ne 0) { throw "Failed to build" } 
 }


### PR DESCRIPTION
A second '/bl' parameter to msbuild looks to have been causing the filename specified in the first one to be ignored,
which meant the log filename didn't match what was set up in the build definition
