### PR TITLE
Replace private System.AppDomain reflection with a regular call

### DIFF
--- a/TestAssets/TestPackages/dotnet-portable/Program.cs
+++ b/TestAssets/TestPackages/dotnet-portable/Program.cs
@@ -13,19 +13,10 @@ namespace ConsoleApplication
         {
             Console.WriteLine("Hello Portable World!");
 
-            var depsFile = new FileInfo(GetDataFromAppDomain("FX_DEPS_FILE"));
+            var depsFile = new FileInfo(AppContext.GetData("FX_DEPS_FILE") as string);
             string frameworkVersion = depsFile.Directory.Name;
 
             Console.WriteLine($"I'm running on shared framework version {frameworkVersion}!");
-        }
-
-        public static string GetDataFromAppDomain(string propertyName)
-        {
-            var appDomainType = typeof(object).GetTypeInfo().Assembly?.GetType("System.AppDomain");
-            var currentDomain = appDomainType?.GetProperty("CurrentDomain")?.GetValue(null);
-            var deps = appDomainType?.GetMethod("GetData")?.Invoke(currentDomain, new[] { propertyName });
-
-            return deps as string;
         }
     }
 }


### PR DESCRIPTION
Fixes dotnet/cli#10399
