### PR TITLE
improve build usability on Linux

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -49,7 +49,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 REPOROOT="$DIR"
-CONFIGURATION="debug"
+CONFIGURATION="Debug"
 ARCHITECTURE="x64"
 STAGE0_SOURCE_DIR=
 


### PR DESCRIPTION
when one simply runs build.sh (or run-build.sh) on Linux it always fails. 


> The test source file "/mnt/github/core-sdk/bin/3/linux-x64/bin/EndToEnd/debug/netcoreapp3.0/EndToEnd.dll" provided was not found.

However, EndtoEnd.dll exists

> file /mnt/github/core-sdk/bin/3/linux-x64/bin/EndToEnd/Debug/netcoreapp3.0/EndToEnd.dll
> /mnt/github/core-sdk/bin/3/linux-x64/bin/EndToEnd/Debug/netcoreapp3.0/EndToEnd.dll: PE32 executable (console) Intel 80386 Mono/.Net assembly, for MS Windows

The difference is that managed build defaults to Configuration=Debug. It does not mater on Windows or OSX where file system is not case sensitive. But on typical Linux machine it would always fail.

This change simple makes shell script and  managed parts in sync. 
Running build.sh without any arguments now works on Linux.


