### PR TITLE
make GivenDotnetUsesDotnetTools test optional based on AspNetCore availability

### DIFF
--- a/test/EndToEnd/GivenDotnetUsesDotnetTools.cs
+++ b/test/EndToEnd/GivenDotnetUsesDotnetTools.cs
@@ -6,7 +6,7 @@ namespace EndToEnd
 {
     public class GivenDotnetUsesDotnetTools : TestBase
     {
-        [Fact]
+        [RequiresAspNetCore]
         public void ThenOneDotnetToolsCanBeCalled()
         {
             new DotnetCommand()

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private string _builtDotnet;
         private string _nugetPackages;
         private string _stage2Sdk;
+        private string _stage2AspNetCore;
         private string _stage2WithBackwardsCompatibleRuntimesDirectory;
         private string _testPackages;
         private string _testWorkingFolder;
@@ -90,6 +91,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         public string DotnetRoot => _dotnetRoot;
         public string NugetPackages => _nugetPackages;
         public string Stage2Sdk => _stage2Sdk;
+        public string Stage2AspNetCore => _stage2AspNetCore;
         public string Stage2WithBackwardsCompatibleRuntimesDirectory => _stage2WithBackwardsCompatibleRuntimesDirectory;
         public string TestPackages => _testPackages;
         public string TestWorkingFolder => _testWorkingFolder;
@@ -115,6 +117,12 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             _stage2Sdk = Directory
                 .EnumerateDirectories(Path.Combine(_artifacts, "dotnet", "sdk"))
                 .First(d => !d.Contains("NuGetFallbackFolder"));
+
+            string AspNetCoreDir = Path.Combine(_dotnetRoot, "shared", "Microsoft.AspNetCore.App");
+            if (Directory.Exists(AspNetCoreDir))
+            {
+                _stage2AspNetCore = Directory.EnumerateDirectories(AspNetCoreDir).First();
+            }
 
             _stage2WithBackwardsCompatibleRuntimesDirectory =
                 Path.Combine(_artifacts, "dotnetWithBackwardsCompatibleRuntimes");

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RequiresAspNetCore.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RequiresAspNetCore.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class RequiresAspNetCore : FactAttribute
+    {
+        public RequiresAspNetCore()
+        {
+            var  d = new RepoDirectoriesProvider();
+            
+            if (d.Stage2AspNetCore == null)
+            {
+                this.Skip = $"This test requires a AspNetCore but isn't present.";
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RequiresAspNetCore.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RequiresAspNetCore.cs
@@ -9,11 +9,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     {
         public RequiresAspNetCore()
         {
-            var  d = new RepoDirectoriesProvider();
+            var  repoDirectoriesProvider = new RepoDirectoriesProvider();
             
-            if (d.Stage2AspNetCore == null)
+            if (repoDirectoriesProvider.Stage2AspNetCore == null)
             {
-                this.Skip = $"This test requires a AspNetCore but isn't present.";
+                this.Skip = $"This test requires a AspNetCore but it isn't present.";
             }
         }
     }


### PR DESCRIPTION
When we build with /p:IncludeAspNetCoreRuntime=false (like on FreeBSD) GivenDotnetUsesDotnetTools  test always fails. 

This change adds simple mechanism to determine if stage2 CLI has AspNetCore included, little xunit extension and condition to  ThenOneDotnetToolsCanBeCalled test it self. 

I verified that with this all tests do pass on FreeBSD:
```
         Total tests: 34. Passed: 26. Failed: 0. Skipped: 8.
         Test Run Successful.
         Test execution time: 2.5381 Minutes
```

I also verified that the test still runs on Linux. (as it should) 