### PR TITLE
Fixes the layout of the dotnet-internal artifacts

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -311,8 +311,7 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(SdkInternalFiles)"
-          DestinationFolder="$(SdkInternalLayoutPath)sdk/$(SdkVersion)"/>
-
+          DestinationFiles="@(SdkInternalFiles -> '$(SdkInternalLayoutPath)sdk\$(SdkVersion)\%(RecursiveDir)%(Filename)%(Extension)')"/>
 
   </Target>
 </Project>


### PR DESCRIPTION
Fixes the layout of the dotnet-internal artifacts, which are used by the chained pkg, msi and -internal.zips/tarballs. We were flattenning all files in the folder.

Fixes https://github.com/dotnet/cli/issues/10514