### PR TITLE
Additional information about shared frameworks to bundled versions 

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -18,6 +18,8 @@ function InitializeCustomSDKToolset {
 
 function CreateBuildEnvScript()
 {
+  InitializeBuildTool | Out-Null # Make sure DOTNET_INSTALL_DIR is set
+
   Create-Directory $ArtifactsDir
   $scriptPath = Join-Path $ArtifactsDir "core-sdk-build-env.bat"
   $scriptContents = @"

--- a/src/core-sdk-tasks/GetRuntimePackRids.cs
+++ b/src/core-sdk-tasks/GetRuntimePackRids.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GetRuntimePackRids : Task
+    {
+        [Required]
+        public string MetapackagePath { get; set; }
+
+        [Output]
+        public ITaskItem[] AvailableRuntimePackRuntimeIdentifiers { get; set; }
+
+        public override bool Execute()
+        {
+            string runtimeJsonPath = Path.Combine(MetapackagePath, "runtime.json");
+            string runtimeJsonContents = File.ReadAllText(runtimeJsonPath);
+            var runtimeJsonRoot = JObject.Parse(runtimeJsonContents);
+            string [] runtimeIdentifiers = ((JObject)runtimeJsonRoot["runtimes"]).Properties().Select(p => p.Name).ToArray();
+            AvailableRuntimePackRuntimeIdentifiers = runtimeIdentifiers.Select(rid => new TaskItem(rid)).ToArray();
+            return true;
+        }
+    }
+}

--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(CoreSdkTargetFramework);net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(CoreSdkTargetFramework)</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>Microsoft.DotNet.Cli.Build</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NuGet.Versioning" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.4.0"/>
+    <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="targets\DownloadPackage.csproj" />
     <None Include="targets\LayoutTool.csproj" />
   </ItemGroup>
 

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -36,5 +36,6 @@
   <UsingTask TaskName="Crossgen" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="CopyBlobsToLatest" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(CoreSdkTaskDll)"/>
+  <UsingTask TaskName="GetRuntimePackRids" AssemblyFile="$(CoreSdkTaskDll)"/>
 
 </Project>

--- a/src/redist/targets/DownloadPackage.csproj
+++ b/src/redist/targets/DownloadPackage.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -44,6 +44,47 @@
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
     </PropertyGroup>
 
+    <!-- Download "metapackages" for each shared framework in order to get the list of runtime identifers
+         for which there are runtime packs (from the runtime.json in the metapackage) -->
+    <ItemGroup>
+      <MetaPackageDownload Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
+        <Properties>
+          PackageToRestore=Microsoft.NETCore.App;
+          PackageVersionToRestore=$(MicrosoftNETCoreAppPackageVersion);
+          TargetFramework=$(TargetFramework)
+        </Properties>
+      </MetaPackageDownload>
+      <MetaPackageDownload Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
+        <Properties>
+          PackageToRestore=Microsoft.WindowsDesktop.App;
+          PackageVersionToRestore=$(MicrosoftWindowsDesktopPackageVersion);
+          TargetFramework=$(TargetFramework)
+        </Properties>
+      </MetaPackageDownload>
+      <MetaPackageDownload Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
+        <Properties>
+          PackageToRestore=Microsoft.AspNetCore.App;
+          PackageVersionToRestore=$(MicrosoftAspNetCoreAppPackageVersion);
+          TargetFramework=$(TargetFramework)
+        </Properties>
+      </MetaPackageDownload>
+    </ItemGroup>
+
+    <MSBuild
+      BuildInParallel="False"
+      Projects="@(MetaPackageDownload)">
+    </MSBuild>
+
+    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.netcore.app/$(MicrosoftNETCoreAppPackageVersion)">
+      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="NetCoreRuntimePackRids" />
+    </GetRuntimePackRids>
+    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.windowsdesktop.app/$(MicrosoftWindowsDesktopPackageVersion)">
+      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="WindowsDesktopRuntimePackRids" />
+    </GetRuntimePackRids>
+    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.aspnetcore.app/$(MicrosoftAspNetCoreAppPackageVersion)">
+      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="AspNetCoreRuntimePackRids" />
+    </GetRuntimePackRids>
+
     <!--
         Setting the property to true if patch == 0 and preview == true. SDK will set DefaultNetCorePatchVersion according to this flag.
         So that we don't need to manually update the version selection logic between when we ship a final release and when we ship the first patch
@@ -151,6 +192,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     @(ImplicitPackageVariable->'<ImplicitPackageReferenceVersion Include="%(Identity)" TargetFrameworkVersion="%(TargetFrameworkVersion)" DefaultVersion="%(DefaultVersion)" LatestVersion="%(LatestVersion)"/>', '
     ')
 
+    <KnownFrameworkReference Include="Microsoft.NETCore.App"
+                              TargetFramework="netcoreapp3.0"
+                              RuntimeFrameworkName="Microsoft.NETCore.App"
+                              DefaultRuntimeFrameworkVersion="$(_NETCoreAppPackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(_NETCoreAppPackageVersion)"
+                              TargetingPackName="Microsoft.NETCore.App"
+                              TargetingPackVersion="$(_NETCoreAppPackageVersion)"
+                              AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
+                              AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids)"
+                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
+                              RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids)"
+                              />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="netcoreapp3.0"
@@ -159,6 +212,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopPackageVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App"
                               TargetingPackVersion="$(MicrosoftWindowsDesktopPackageVersion)"
+                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.WindowsDesktop.App"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids)"
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
@@ -168,6 +223,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
                               TargetingPackName="Microsoft.AspNetCore.App"
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
+                              RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids)"
                               />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds known framework information for the base .NET Core shared framework, and adds information about runtime packs for shared frameworks.  This information will be consumed by logic in https://github.com/dotnet/sdk/pull/2774.

With this PR, the known framework information looks like this:

```xml
    <KnownFrameworkReference Include="Microsoft.NETCore.App"
                              TargetFramework="netcoreapp3.0"
                              RuntimeFrameworkName="Microsoft.NETCore.App"
                              DefaultRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              LatestRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              TargetingPackName="Microsoft.NETCore.App"
                              TargetingPackVersion="3.0.0-preview-27218-01"
                              AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
                              AppHostRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                              RuntimePackRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                              />
    
    <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                              TargetFramework="netcoreapp3.0"
                              RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                              DefaultRuntimeFrameworkVersion="3.0.0-alpha-27218-5"
                              LatestRuntimeFrameworkVersion="3.0.0-alpha-27218-5"
                              TargetingPackName="Microsoft.WindowsDesktop.App"
                              TargetingPackVersion="3.0.0-alpha-27218-5"
                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.WindowsDesktop.App"
                              RuntimePackRuntimeIdentifiers="win-x64;win-x86"
                              />

    <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
                              TargetFramework="netcoreapp3.0"
                              RuntimeFrameworkName="Microsoft.AspNetCore.App"
                              DefaultRuntimeFrameworkVersion="3.0.0-preview-18579-0056"
                              LatestRuntimeFrameworkVersion="3.0.0-preview-18579-0056"
                              TargetingPackName="Microsoft.AspNetCore.App"
                              TargetingPackVersion="3.0.0-preview-18579-0056"
                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
                              RuntimePackRuntimeIdentifiers="win-x64;win-x86;win-arm;osx-x64;linux-musl-x64;linux-x64;linux-arm;linux-arm64"
                              />
```

The runtime identifiers for which runtime packs and apphost packs are available are generated by parsing the runtime.json from the corresponding NuGet package (e.g. Microsoft.NETCore.App).  This may change as we evolve what targeting packs look like.  @ericstj @natemcmaster 