### PR TITLE
Escape semicolons when generating bundled versions

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -200,9 +200,9 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.NETCore.App"
                               TargetingPackVersion="$(_NETCoreAppPackageVersion)"
                               AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
-                              AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids)"
-                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
-                              RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids)"
+                              AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
+                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
+                              RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
@@ -213,7 +213,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.WindowsDesktop.App"
                               TargetingPackVersion="$(MicrosoftWindowsDesktopPackageVersion)"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.WindowsDesktop.App"
-                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids)"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
@@ -224,7 +224,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.AspNetCore.App"
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
-                              RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids)"
+                              RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
                               />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Generate `KnownFrameworkReference` items like this:

```xml
    <KnownFrameworkReference Include="Microsoft.NETCore.App"
                              TargetFramework="netcoreapp3.0"
                              RuntimeFrameworkName="Microsoft.NETCore.App"
                              DefaultRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              LatestRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              TargetingPackName="Microsoft.NETCore.App"
                              TargetingPackVersion="3.0.0-preview-27218-01"
                              AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
                              AppHostRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App;runtime.**RID**.Microsoft.NETCore.DotNetHostResolver;runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                              RuntimePackRuntimeIdentifiers="freebsd-x64;linux-arm;linux-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
                              />
```

Instead of like this:

```xml
    <KnownFrameworkReference Include="Microsoft.NETCore.App"
                              TargetFramework="netcoreapp3.0"
                              RuntimeFrameworkName="Microsoft.NETCore.App"
                              DefaultRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              LatestRuntimeFrameworkVersion="3.0.0-preview-27218-01"
                              TargetingPackName="Microsoft.NETCore.App"
                              TargetingPackVersion="3.0.0-preview-27218-01"
                              AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
                              AppHostRuntimeIdentifiers="freebsd-x64
linux-arm
linux-arm64
linux-musl-x64
linux-x64
osx-x64
rhel.6-x64
tizen.4.0.0-armel
tizen.5.0.0-armel
win-arm
win-arm64
win-x64
win-x86"
                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App
runtime.**RID**.Microsoft.NETCore.DotNetHostResolver
runtime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                              RuntimePackRuntimeIdentifiers="freebsd-x64
linux-arm
linux-arm64
linux-musl-x64
linux-x64
osx-x64
rhel.6-x64
tizen.4.0.0-armel
tizen.5.0.0-armel
win-arm
win-arm64
win-x64
win-x86"
                              />
```