### PR TITLE
Insertion for 3.0 test templates.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
   <PropertyGroup>
     <MicrosoftDotNetCommonItemTemplatesPackageVersion>1.0.2-beta5.19054.5</MicrosoftDotNetCommonItemTemplatesPackageVersion>
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates22PackageVersion>1.0.2-beta4-20181021-2140732</MicrosoftDotNetTestProjectTemplates22PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4-20181228-2300159</MicrosoftDotNetTestProjectTemplates30PackageVersion>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
     <NUnit3TemplatesVersion>1.5.1</NUnit3TemplatesVersion>
   </PropertyGroup>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -2,7 +2,7 @@
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(MicrosoftDotNetCommonItemTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.2" Version="$(MicrosoftDotNetTestProjectTemplates22PackageVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.3.0" Version="$(MicrosoftDotNetTestProjectTemplates30PackageVersion)" />
     <BundledTemplate Include="Microsoft.Dotnet.Wpf.ProjectTemplates" Version="$(MicrosoftDotnetWpfProjectTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)" />
 


### PR DESCRIPTION
- Adding the test templates targeting Net Core 3.0
- Templates built from https://github.com/dotnet/test-templates/tree/master/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0

