### PR TITLE
Added new package feed as input to coresdk

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,9 +2,9 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-alpha-27309-3">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview-27310-7">
       <Uri>https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted</Uri>
-      <Sha>63610380c84a0d348c63651e9194aac5a87738b0</Sha>
+      <Sha>0f06f9b915f7fb35d7245d168b1428f377abc76c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27309-1">
       <Uri>https://github.com/dotnet/core-setup</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,7 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-alpha-27309-3</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview-27310-7</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
     <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
@@ -63,6 +63,7 @@
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/templating/api/v3/index.json;
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -177,6 +177,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <AddDotnetfeedProjectSource Condition="'%24(AddDotnetfeedProjectSource)' == ''">%24(_NETCoreSdkIsPreview)</AddDotnetfeedProjectSource>
     <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json</RestoreAdditionalProjectSources>
     <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</RestoreAdditionalProjectSources>
 
     <!-- Default patch versions for each minor version of ASP.NET Core -->


### PR DESCRIPTION
There is an ongoing issue with resource contention where many projects need to wait for an exclusive lock on the dotnet feed when publishing packages. This is causing many of our builds to timeout, so the workaround suggested by Matt Mitchell is to push to a new feed.

Both winforms and WindowsDesktop are now pushing to the new feed, so this PR is to add this feed as an input to the coresdk build.

I tested this by running "darc update-dependencies" to get our dependency on the right version, then building locally to make sure the latest package versions were getting restored correctly. They only exist in the new feed, so this proves it's working properly.