### PR TITLE
Updating the property name for toolset dependency uptake

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup>
-    <dotnettoolsetinternalPackageVersion>3.0.100-preview.19057.5</dotnettoolsetinternalPackageVersion>
+    <MicrosoftDotnetToolsetInternalPackageVersion>3.0.100-preview.19057.5</MicrosoftDotnetToolsetInternalPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/EntityFrameworkCore -->

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -111,8 +111,8 @@
       </BundledInstallerComponent>
     
       <BundledLayoutComponent Include="ToolsetArchive">
-        <BaseUrl>$(CoreSetupBlobRootUrl)Toolset/$(dotnettoolsetinternalPackageVersion)</BaseUrl>
-        <DownloadFileName>dotnet-toolset-internal-$(dotnettoolsetinternalPackageVersion).zip</DownloadFileName>
+        <BaseUrl>$(CoreSetupBlobRootUrl)Toolset/$(MicrosoftDotnetToolsetInternalPackageVersion)</BaseUrl>
+        <DownloadFileName>dotnet-toolset-internal-$(MicrosoftDotnetToolsetInternalPackageVersion).zip</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
         <RelativeLayoutPath>sdk/$(SdkVersion)</RelativeLayoutPath>
       </BundledLayoutComponent>


### PR DESCRIPTION
Updating the property name for toolset dependency uptake based on the fake package being published there.
