### PR TITLE
Change the name of sign parameters.

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -61,6 +61,7 @@ phases:
                   -Configuration $(_BuildConfig)
                   -Architecture $(_BuildArchitecture)
                   $(_BuildArgs)
+                  $(SignBuildParameters)
                   $(_AdditionalBuildParameters)
         displayName: Build
         env:

--- a/eng/setbuildinfo.bat
+++ b/eng/setbuildinfo.bat
@@ -35,4 +35,4 @@ IF /I "%Architecture:~0,3%"=="ARM" (
 
 )
 
-ECHO ##vso[task.setvariable variable=AdditionalBuildParameters]-sign /p:DotNetSignType=%SignType%
+ECHO ##vso[task.setvariable variable=SignBuildParameters]-sign /p:DotNetSignType=%SignType%


### PR DESCRIPTION
Change the name of sign parameters. We had it as AdditionalBuildParameter but we stopped passing that to the actual build.

