### PR TITLE
Differentiate manifests

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -24,11 +24,12 @@
   
   <PropertyGroup>
       <!-- Because we may be building in a container, we should use an asset manifest file path
-             that exists in the container. Disambiguate the manifests via RID and architecture -->
-      <AssetManifestFileName Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)-$(PlatformName)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(AGENT_OS)' == ''">$(OS)-$(PlatformName)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(Rid)' != ''">$(AssetManifestFileName)-$(Rid)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(Architecture)' != ''">$(AssetManifestFileName)-$(Architecture)</AssetManifestFileName>
+             that exists in the container. Disambiguate the manifests via available properties.
+             AGENT_OS and AGENT_JOBNAME are present on Azure DevOps agents -->
+      <AssetManifestFileName Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)</AssetManifestFileName>
+      <AssetManifestFileName Condition="'$(AGENT_OS)' == ''">$(OS)</AssetManifestFileName>
+      <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' != ''">$(AssetManifestFileName)-$(AGENT_JOBNAME)</AssetManifestFileName>
+      <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' == '' and '$(Architecture)' != ''">$(AssetManifestFileName)-$(Architecture)</AssetManifestFileName>
       <ChecksumsAssetManifestFileName>$(AssetManifestFileName)-checksums</ChecksumsAssetManifestFileName>
       <!-- Property AssetManifestFilePath will be reassigned by the Arcade SDK, so use a different name (DotNetAssetManifestFilePath) -->
       <DotNetAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName).xml</DotNetAssetManifestFilePath>

--- a/eng/dockerrun.sh
+++ b/eng/dockerrun.sh
@@ -148,5 +148,7 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e BUILD_SOURCEBRANCH \
     -e BUILD_BUILDNUMBER \
     -e BUILD_SOURCEVERSION \
+    -e AGENT_JOBNAME \
+    -e AGENT_OS \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
We were hitting manifest name collisions on some Linux jobs.

Validated with https://dev.azure.com/dnceng/internal/_build/results?definitionId=286&_a=summary&buildId=81444

FYI @livarcocc 