### PR TITLE
Add KnownAppHost item to bundled versions

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -206,6 +206,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                               RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               />
+
+    <KnownAppHostPack Include="Microsoft.NETCore.App"
+                      TargetFramework="netcoreapp3.0"
+                      AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
+                      AppHostPackVersion="$(_NETCoreAppPackageVersion)"
+                      AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
+                      />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="netcoreapp3.0"


### PR DESCRIPTION
Adds a `KnownAppHost` item with apphost pack information.  This will be consumed by the refactored logic in https://github.com/dotnet/sdk/pull/2887.

Previously, there was metadata on the `KnownFrameworkReference` for `Microsoft.NETCore.App` about the app host.  This ended up not being super clean, as the framework reference resolution logic expected exactly one of the applicable known framework references to include information about the app host.