### PR TITLE
Add bundled version information for targeting .NET Standard 2.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,6 +26,10 @@
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>536d6a237f4de7b248e75b63256b75c1798e1bd7</Sha>
     </Dependency>
+    <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19078.1">
+      <Uri>https://github.com/dotnet/standard</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19107.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,6 +32,9 @@
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <NETStandardLibraryPackageVersion>2.1.0-prerelease.19078.1</NETStandardLibraryPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <MicrosoftDotNetCommonItemTemplatesPackageVersion>1.0.2-beta5.19066.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
     <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.19106.1</MicrosoftDotNetTestProjectTemplates30PackageVersion>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -99,11 +99,11 @@
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="1.0"
                                DefaultVersion="1.0.5"
-                               LatestVersion="1.0.13" />
+                               LatestVersion="1.0.14" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="1.1"
                                DefaultVersion="1.1.2"
-                               LatestVersion="1.1.10" />
+                               LatestVersion="1.1.11" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.0"
                                DefaultVersion="2.0.0"
@@ -111,11 +111,11 @@
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.0"
-                               LatestVersion="2.1.7" />
+                               LatestVersion="2.1.8" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.2"
                                DefaultVersion="2.2.0"
-                               LatestVersion="2.2.1" />
+                               LatestVersion="2.2.2" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="3.0"
                                DefaultVersion="$(_NETCoreAppPackageVersion)"
@@ -124,20 +124,20 @@
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.1"
-                               LatestVersion="2.1.7"/>
+                               LatestVersion="2.1.8"/>
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.1"
-                               LatestVersion="2.1.7"/>
+                               LatestVersion="2.1.8"/>
 
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
                                TargetFrameworkVersion="2.2"
                                DefaultVersion="2.2.0"
-                               LatestVersion="2.2.1"/>
+                               LatestVersion="2.2.2"/>
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
                                TargetFrameworkVersion="2.2"
                                DefaultVersion="2.2.0"
-                               LatestVersion="2.2.1"/>
+                               LatestVersion="2.2.2"/>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -235,6 +235,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
                               />
+                              
+     <KnownFrameworkReference Include="NETStandard.Library"
+                              TargetFramework="netstandard2.1"
+                              TargetingPackName="NETStandard.Library"
+                              TargetingPackVersion="$(NETStandardLibraryPackageVersion)"
+                              TargetingPackFormat="NETStandardLegacy"
+                              />
+
   </ItemGroup>
 </Project>
 ]]>


### PR DESCRIPTION
Add `KnownFrameworkReference` information for .NET Standard 2.1