### PR TITLE
Use .Ref targeting packs and include in layout under packs folder

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -161,6 +161,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
   <PropertyGroup>
+    <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\packs'))</NetCoreTargetingPackRoot>
+  
     <NETCoreAppMaximumVersion>$(_NETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
@@ -199,8 +201,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimeFrameworkName="Microsoft.NETCore.App"
                               DefaultRuntimeFrameworkVersion="$(_NETCoreAppPackageVersion)"
                               LatestRuntimeFrameworkVersion="$(_NETCoreAppPackageVersion)"
-                              TargetingPackName="Microsoft.NETCore.App"
-                              TargetingPackVersion="$(_NETCoreAppPackageVersion)"
+                              TargetingPackName="Microsoft.NETCore.App.Ref"
+                              TargetingPackVersion="$(NetCoreAppTargetingPackVersion)"
                               AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
                               AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
@@ -230,8 +232,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
-                              TargetingPackName="Microsoft.AspNetCore.App"
-                              TargetingPackVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              TargetingPackName="Microsoft.AspNetCore.App.Ref"
+                              TargetingPackVersion="$(AspNetTargetingPackVersion)"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
                               />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -70,6 +70,18 @@
         <RelativeLayoutPath></RelativeLayoutPath>
       </BundledLayoutComponent>
 
+      <BundledLayoutPackage Include="MicrosoftNetCoreAppTargetingPackNupkg">
+        <PackageName>Microsoft.NETCore.App.Ref</PackageName>
+        <PackageVersion>$(NetCoreAppTargetingPackVersion)</PackageVersion>
+        <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
+      </BundledLayoutPackage>
+
+      <BundledLayoutPackage Include="MicrosoftAspNetCoreAppTargetingPackNupkg">
+        <PackageName>Microsoft.AspNetCore.App.Ref</PackageName>
+        <PackageVersion>$(AspNetTargetingPackVersion)</PackageVersion>
+        <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
+      </BundledLayoutPackage>
+
       <BundledInstallerComponent Include="DownloadedRuntimeDepsInstallerFile"
                                  Condition="('$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true') And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</BaseUrl>
@@ -183,7 +195,52 @@
     <DownloadFile Condition=" '@(ComponentToDownload)' != '' And '%(ComponentToDownload.ShouldDownload)' == 'true'"
                   Uri="%(ComponentToDownload.BaseUrl)/%(ComponentToDownload.DownloadFileName)"
                   DestinationPath="%(ComponentToDownload.DownloadDestination)" />
-    
+
+    <ItemGroup>
+      <BundledLayoutPackageDownloadProject Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
+        <Properties>
+          PackageToRestore=%(BundledLayoutPackage.PackageName);
+          PackageVersionToRestore=%(BundledLayoutPackage.PackageVersion);
+          TargetFramework=$(TargetFramework);
+          LayoutPackageDescription=%(BundledLayoutPackage.Identity)
+        </Properties>
+      </BundledLayoutPackageDownloadProject>
+    </ItemGroup>
+
+    <MSBuild
+      BuildInParallel="False"
+      Projects="@(BundledLayoutPackageDownloadProject)">
+    </MSBuild>
+
+    <ItemGroup>
+      <!-- Use lowercase package name in package path -->
+      <BundledLayoutPackage>
+        <LoweredPackageName>$([MSBuild]::ValueOrDefault('%(BundledLayoutPackage.PackageName)', '').ToLower())</LoweredPackageName>
+      </BundledLayoutPackage>
+      
+      <BundledLayoutPackageDownloadFiles Include="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\**\*.*">
+        <RelativeLayoutPath>%(BundledLayoutPackage.RelativeLayoutPath)</RelativeLayoutPath>
+        <LayoutPackageDescription>%(BundledLayoutPackage.Identity)</LayoutPackageDescription>
+      </BundledLayoutPackageDownloadFiles>
+
+      <!-- Remove files from the root of the package, as these are either files NuGet writes, or not necessary -->
+      <BundledLayoutPackageDownloadFiles Remove="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\*.*" />
+
+      <!-- Set destination path in layout -->
+      <BundledLayoutPackageDownloadFiles>
+        <DestinationPath>%(BundledLayoutPackageDownloadFiles.RecursiveDir)%(BundledLayoutPackageDownloadFiles.Filename)%(BundledLayoutPackageDownloadFiles.Extension)</DestinationPath>
+      </BundledLayoutPackageDownloadFiles>
+      <BundledLayoutPackageDownloadFiles>
+        <DestinationPath>$(RedistLayoutPath)/%(BundledLayoutPackageDownloadFiles.RelativeLayoutPath)/%(BundledLayoutPackageDownloadFiles.DestinationPath)</DestinationPath>
+      </BundledLayoutPackageDownloadFiles>
+      <BundledLayoutPackageDownloadFiles>
+        <DestinationPath>$([MSBuild]::NormalizePath(%(BundledLayoutPackageDownloadFiles.DestinationPath)))</DestinationPath>
+      </BundledLayoutPackageDownloadFiles>
+
+      <!-- Creating a new item here isn't strictly necessary, but makes it easier to see what's going on in the .binlog,
+           since the metadata updates don't show up there -->
+      <BundledLayoutPackageDownloadFilesWithDestination Include="@(BundledLayoutPackageDownloadFiles)"/>
+    </ItemGroup>
   </Target>
 
   <Target Name="CleanLayoutPath">
@@ -192,9 +249,15 @@
     <MakeDir Directories="$(RedistLayoutPath)" />
   </Target>
 
-  <Target Name="ExtractBundledComponents">
+  <Target Name="LayoutBundledComponents">
     <ExtractArchiveToDirectory SourceArchive="%(BundledLayoutComponent.DownloadDestination)"
-                               DestinationDirectory="$(RedistLayoutPath)/%(BundledLayoutComponent.RelativeLayoutPath)" />    
+                               DestinationDirectory="$(RedistLayoutPath)/%(BundledLayoutComponent.RelativeLayoutPath)" />
+
+    <Copy SourceFiles="@(BundledLayoutPackageDownloadFilesWithDestination)"
+          DestinationFiles="@(BundledLayoutPackageDownloadFilesWithDestination->'%(DestinationPath)')"
+          SkipUnchangedFiles="true"
+          />
+    
   </Target>
 
   <Target Name="RetargetTools">
@@ -285,7 +348,7 @@
   <Target Name="GenerateLayout"
           DependsOnTargets="DownloadBundledComponents;
                             CleanLayoutPath;
-                            ExtractBundledComponents;
+                            LayoutBundledComponents;
                             GenerateVersionFile;
                             GenerateBundledVersions;
                             LayoutRuntimeGraph;

--- a/test/EndToEnd/GivenAspNetAppsResolveImplicitVersions.cs
+++ b/test/EndToEnd/GivenAspNetAppsResolveImplicitVersions.cs
@@ -106,6 +106,12 @@ namespace EndToEnd
         [MemberData(nameof(SupportedAspNetCoreAppVersions))]
         public void ItRollsForwardToTheLatestVersion(string minorVersion)
         {
+            if (minorVersion == "3.0")
+            {
+                //  https://github.com/dotnet/core-sdk/issues/621
+                return;
+            }
+
             var testProjectCreator = new TestProjectCreator(identifier: minorVersion)
             {
                 PackageName = TestProjectCreator.AspNetCoreAppPackageName,

--- a/test/EndToEnd/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd/GivenFrameworkDependentApps.cs
@@ -19,6 +19,11 @@ namespace EndToEnd
         [ClassData(typeof(SupportedNetCoreAppVersions))]
         public void ItDoesNotRollForwardToTheLatestVersionOfNetCore(string minorVersion)
         {
+            if (minorVersion == "3.0")
+            {
+                //  https://github.com/dotnet/core-sdk/issues/621
+                return;
+            }
             ItDoesNotRollForwardToTheLatestVersion(TestProjectCreator.NETCorePackageName, minorVersion);
         }
 
@@ -26,6 +31,11 @@ namespace EndToEnd
         [ClassData(typeof(SupportedAspNetCoreVersions))]
         public void ItDoesNotRollForwardToTheLatestVersionOfAspNetCoreApp(string minorVersion)
         {
+            if (minorVersion == "3.0")
+            {
+                //  https://github.com/dotnet/core-sdk/issues/621
+                return;
+            }
             ItDoesNotRollForwardToTheLatestVersion(TestProjectCreator.AspNetCoreAppPackageName, minorVersion);
         }
 

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -23,6 +23,11 @@ namespace EndToEnd
         [ClassData(typeof(SupportedNetCoreAppVersions))]
         public void ItRollsForwardToTheLatestNetCoreVersion(string minorVersion)
         {
+            if (minorVersion == "3.0")
+            {
+                //  https://github.com/dotnet/core-sdk/issues/621
+                return;
+            }
             ItRollsForwardToTheLatestVersion(TestProjectCreator.NETCorePackageName, minorVersion);
         }
 
@@ -30,6 +35,11 @@ namespace EndToEnd
         [ClassData(typeof(SupportedAspNetCoreVersions))]
         public void ItRollsForwardToTheLatestAspNetCoreAppVersion(string minorVersion)
         {
+            if (minorVersion == "3.0")
+            {
+                //  https://github.com/dotnet/core-sdk/issues/621
+                return;
+            }
             ItRollsForwardToTheLatestVersion(TestProjectCreator.AspNetCoreAppPackageName, minorVersion);
         }
 


### PR DESCRIPTION
- Switch to .Ref targeting packs in KnownFrameworkReferences for .NET Core and ASP.NET Core
- Layout .Ref targeting packs under packs folder in compressed layouts

This PR currently includes the changes from #588, once that is merged I will rebase it.  So for now, it's easiest to review commit by commit, starting with my commits.