### PR TITLE
[3.0-preview3] replace aspnetcore-dev myget feed with dotnetfeed

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,9 +10,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>80d779364c184bba11b3d62d32894b7eb0469835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App" Version="3.0.0-preview3-19121-17">
+    <Dependency Name="Microsoft.AspNetCore.App" Version="3.0.0-preview3-19122-02">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
-      <Sha>8a0adf1cfc43578e8a4a4f767bb206d871172a58</Sha>
+      <Sha>57092e96ac4a45b143bd6edd631923896fe12a56</Sha>
     </Dependency>
     <Dependency Name="dotnet-ef" Version="3.0.0-preview3.19122.14">
       <Uri>https://github.com/aspnet/EntityFrameworkCore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview3-19121-17</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview3-19122-02</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetDevCertsPackageVersion>
     <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetSqlCachePackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,8 +70,11 @@
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/templating/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
+      https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -180,8 +180,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AddDotnetfeedProjectSource Condition="'%24(AddDotnetfeedProjectSource)' == ''">%24(_NETCoreSdkIsPreview)</AddDotnetfeedProjectSource>
     <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreAdditionalProjectSources>
     <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json</RestoreAdditionalProjectSources>
-    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</RestoreAdditionalProjectSources>
-
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition="'%24(AddDotnetfeedProjectSource)' == 'true'">%24(RestoreAdditionalProjectSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json</RestoreAdditionalProjectSources>
+ 
     <!-- Default patch versions for each minor version of ASP.NET Core -->
     <DefaultPatchVersionForAspNetCoreAll2_1>2.1.1</DefaultPatchVersionForAspNetCoreAll2_1>
     <DefaultPatchVersionForAspNetCoreApp2_1>2.1.1</DefaultPatchVersionForAspNetCoreApp2_1>


### PR DESCRIPTION
React to changes in publishing settings for aspnetcore packages. We stopped publishing aspnet packages to https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json because there was too much contention for this feed. We now have individual feeds for each aspnet repo.

