### PR TITLE
Update SDK to use aspnet runtime packs

### DIFF
--- a/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
+++ b/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
@@ -23,7 +23,7 @@
   <Target Name="WriteBundledVersionsFile" BeforeTargets="Restore">
     <WriteLinesToFile
       File="$(MSBuildThisFileDirectory)/.BundledAspNetCoreVersion"
-      Lines="$(MicrosoftAspNetCoreAppPackageVersion)"
+      Lines="$(MicrosoftAspNetCoreAppRuntimeX64PackageVersion)"
       Overwrite="true"/>
   </Target>
   

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,7 +10,31 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>d1e2be4f140105dc9aae972f723cb6077a02fd84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App" Version="3.0.0-preview4-19123-01">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-dev-certs" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-sql-cache" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-user-secrets" Version="3.0.0-preview4-19123-01">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-watch" Version="3.0.0-preview4-19123-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
       <Sha>f8368097a909ba2618efbec5efa5e7e036d3a2e8</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,12 +20,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppPackageVersion>3.0.0-preview4-19123-01</MicrosoftAspNetCoreAppPackageVersion>
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
-    <DotnetDevCertsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetDevCertsPackageVersion>
-    <DotnetSqlCachePackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetSqlCachePackageVersion>
-    <DotnetUserSecretsPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetUserSecretsPackageVersion>
-    <DotnetWatchPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</DotnetWatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion>3.0.0-preview4-19123-01</MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>3.0.0-preview4-19123-01</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview4-19123-01</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <DotnetDevCertsPackageVersion>3.0.0-preview4-19123-01</DotnetDevCertsPackageVersion>
+    <DotnetSqlCachePackageVersion>3.0.0-preview4-19123-01</DotnetSqlCachePackageVersion>
+    <DotnetUserSecretsPackageVersion>3.0.0-preview4-19123-01</DotnetUserSecretsPackageVersion>
+    <DotnetWatchPackageVersion>3.0.0-preview4-19123-01</DotnetWatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/cli -->
@@ -53,9 +54,9 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
-    <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
+    <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
+    <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
     <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview4-27428-5</MicrosoftWindowsDesktopAppPackageVersion>
-    <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetTargetingPackVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
     <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -29,17 +29,10 @@
       <_NETCoreAppPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</_NETCoreAppPackageVersion>
       <_NETStandardLibraryPackageVersion>@(_NETStandardLibraryPackageVersions->Distinct())</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>@(_NETCorePlatformsPackageVersions->Distinct())</_NETCorePlatformsPackageVersion>
-      <_AspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</_AspNetCoreAppPackageVersion>
-
-      <!-- Default aspnetcore patch versions, specified as a stabilized version -->
-      <_DefaultPatchVersionForAspNetCoreApp3_0>3.0.0</_DefaultPatchVersionForAspNetCoreApp3_0>
-      <!-- If we are currently building a prerelease of the version that we intend to lock to, set the default version to the ingested version instead of the stabilized version. -->
-      <_DefaultPatchVersionForAspNetCoreApp3_0 Condition="$(_AspNetCoreAppPackageVersion.StartsWith('$(_DefaultPatchVersionForAspNetCoreApp3_0)-'))">$(_AspNetCoreAppPackageVersion)</_DefaultPatchVersionForAspNetCoreApp3_0>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
       <_NETStandardTargetFrameworkVersion>$(_NETStandardLibraryPackageVersion.Split('.')[0]).$(_NETStandardLibraryPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
-      <_AspNetCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</_AspNetCoreAppTargetFrameworkVersion>
 
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
     </PropertyGroup>
@@ -61,13 +54,6 @@
           TargetFramework=$(TargetFramework)
         </Properties>
       </MetaPackageDownload>
-      <MetaPackageDownload Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
-        <Properties>
-          PackageToRestore=Microsoft.AspNetCore.App;
-          PackageVersionToRestore=$(MicrosoftAspNetCoreAppPackageVersion);
-          TargetFramework=$(TargetFramework)
-        </Properties>
-      </MetaPackageDownload>
     </ItemGroup>
 
     <MSBuild
@@ -81,9 +67,18 @@
     <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.windowsdesktop.app/$(MicrosoftWindowsDesktopPackageVersion)">
       <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="WindowsDesktopRuntimePackRids" />
     </GetRuntimePackRids>
-    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.aspnetcore.app/$(MicrosoftAspNetCoreAppPackageVersion)">
-      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="AspNetCoreRuntimePackRids" />
-    </GetRuntimePackRids>
+
+    <ItemGroup>
+      <AspNetCoreRuntimePackRids Include="
+        win-x64;
+        win-x86;
+        win-arm;
+        osx-x64;
+        linux-musl-x64;
+        linux-x64;
+        linux-arm;
+        linux-arm64" />
+    </ItemGroup>
 
     <!--
         Setting the property to true if patch == 0 and preview == true. SDK will set DefaultNetCorePatchVersion according to this flag.
@@ -139,11 +134,6 @@
                                DefaultVersion="2.2.0"
                                LatestVersion="2.2.2"/>
     </ItemGroup>
-    
-    <ItemGroup>
-      <BundledVersionsVariable Include="BundledAspNetCoreAppTargetFrameworkVersion" Value="$(_AspNetCoreAppTargetFrameworkVersion)" />
-      <BundledVersionsVariable Include="BundledAspNetCoreAppPackageVersion" Value="$(_AspNetCoreAppPackageVersion)" />
-    </ItemGroup>
 
     <PropertyGroup>
       <BundledVersionsPropsContent>
@@ -171,8 +161,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
     <BundledRuntimeIdentifierGraphFile>%24(MSBuildThisFileDirectory)RuntimeIdentifierGraph.json</BundledRuntimeIdentifierGraphFile>
-    @(BundledVersionsVariable->'<%(Identity)>%(Value)</%(Identity)>', '
-    ')
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <NETCoreSdkRuntimeIdentifier>$(ProductMonikerRid)</NETCoreSdkRuntimeIdentifier>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
@@ -233,11 +221,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
                               TargetFramework="netcoreapp3.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)"
                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
                               TargetingPackVersion="$(AspNetTargetingPackVersion)"
-                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.AspNetCore.App"
+                              RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
                               />
                               


### PR DESCRIPTION
React to deprecation of Microsoft.AspNetCore.App. https://github.com/aspnet/AspNetCore/pull/7832

Changes:
* Update KnownFrameworkReference to use the new runtime packs
* Stop reference Microsoft.AspNetCore.App
* Stop generating unused variable in the SDK: BundledAspNetCoreAppPackageVersion and BundledAspNetCoreAppTargetFrameworkVersion
* Add prodcon entries for all aspnet dependencies. These may not have the same version in the future (like patch updates)
