### PR TITLE
Generate the graphviz contents on every official build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -290,15 +290,15 @@ jobs:
     condition: succeeded()
     variables:
       # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-      # DotNet-AllOrgs-Pats provides: dn-bot-all-orgs-pat
+      # DotNet-AllOrgs-Pats provides: dn-bot-devdiv-dnceng-rw-code-pat
       - group: Publish-Build-Assets
-      - group: DotNet-AllOrgs-Pats
+      - group: DotNet-AllOrgs-Darc-Pats
     steps:
       - task: PowerShell@2
         displayName: Generate GraphViz graph
         inputs:
           filePath: eng/common/generate-graphviz.ps1
-          arguments: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -azdoPat $(dn-bot-all-orgs-pat) -barToken $(MaestroAccessToken) -outputFolder '$(Build.StagingDirectory)/GraphViz/'
+          arguments: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -azdoPat $(dn-bot-devdiv-dnceng-rw-code-pat) -barToken $(MaestroAccessToken) -outputFolder '$(Build.StagingDirectory)/GraphViz/'
         continueOnError: true
       - task: PublishBuildArtifacts@1
         displayName: Publish Graph to Artifacts

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -290,7 +290,7 @@ jobs:
     condition: succeeded()
     variables:
       # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-      # DotNet-AllOrgs-Pats provides: dn-bot-devdiv-dnceng-rw-code-pat
+      # DotNet-AllOrgs-Darc-Pats provides: dn-bot-devdiv-dnceng-rw-code-pat
       - group: Publish-Build-Assets
       - group: DotNet-AllOrgs-Darc-Pats
     steps:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -276,3 +276,35 @@ jobs:
       enablePublishBuildArtifacts: true
       pool:
         vmImage: vs2017-win2016
+        
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - job: Create_GraphViz
+    displayName: Create GraphViz
+    dependsOn:
+      - Windows_NT
+      - Linux
+      - Darwin
+      - Asset_Registry_Publish
+    pool:
+      name: Hosted VS2017
+    condition: succeeded()
+    variables:
+      # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+      # DotNet-AllOrgs-Pats provides: dn-bot-all-orgs-pat
+      - group: Publish-Build-Assets
+      - group: DotNet-AllOrgs-Pats
+    steps:
+      - task: PowerShell@2
+        displayName: Generate GraphViz graph
+        inputs:
+          filePath: eng/common/generate-graphviz.ps1
+          arguments: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -azdoPat $(dn-bot-all-orgs-pat) -barToken $(MaestroAccessToken) -outputFolder '$(Build.StagingDirectory)/GraphViz/'
+        continueOnError: true
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Graph to Artifacts
+        inputs:
+          PathtoPublish: '$(Build.StagingDirectory)/GraphViz'
+          PublishLocation: Container
+          ArtifactName: GraphViz
+        continueOnError: true
+        condition: always()      

--- a/eng/common/generate-graphviz.ps1
+++ b/eng/common/generate-graphviz.ps1
@@ -1,0 +1,58 @@
+Param(
+  [string] $barToken,
+  [string] $gitHubPat,
+  [string] $azdoPat,
+  [string] $outputFolder,
+  [string] $darcVersion = '1.1.0-beta.19154.2',
+  [switch] $includeToolset
+)
+
+$ErrorActionPreference = "Stop"
+. $PSScriptRoot\tools.ps1
+
+function CheckExitCode ([string]$stage)
+{
+  $exitCode = $LASTEXITCODE
+  if ($exitCode  -ne 0) {
+    Write-Host "Something failed in stage: '$stage'. Check for errors above. Exiting now..."
+    ExitWithExitCode $exitCode
+  }
+}
+
+try {
+  Push-Location $PSScriptRoot
+    
+  Write-Host "Installing darc..."
+  . .\darc-init.ps1 -darcVersion $darcVersion
+  CheckExitCode "Running darc-init"
+
+  $DarcExe = "$env:USERPROFILE\.dotnet\tools"
+  $DarcExe = Resolve-Path $DarcExe
+  
+  if (!(Test-Path -Path $outputFolder)) {
+      Create-Directory $outputFolder
+  }
+    
+  $options = "get-dependency-graph --graphviz '$outputFolder\graphviz.txt' --github-pat $gitHubPat --azdev-pat $azdoPat --password $barToken"
+  
+  if ($includeToolset) {
+    Write-Host "Toolsets will be included in the graph..."
+    $options += " --include-toolset"
+  }
+
+  Write-Host "Generating dependency graph..."
+  $darc = Invoke-Expression "& `"$DarcExe\darc.exe`" $options"
+  $graph = Get-Content $outputFolder\graphviz.txt
+  Set-Content $outputFolder\graphviz.txt -Value "Paste the following digraph object in http://www.webgraphviz.com `r`n", $graph
+  Write-Host "'$outputFolder\graphviz.txt' file created!"
+}
+catch {
+  if (!$includeToolset) {
+    Write-Host "This might be a toolset repo which includes only toolset dependencies. " -NoNewline -ForegroundColor Yellow
+    Write-Host "Since -includeToolset is not set there is no graph to create. Include -includeToolset and try again..." -ForegroundColor Yellow
+  }
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  ExitWithExitCode 1
+}

--- a/eng/common/generate-graphviz.ps1
+++ b/eng/common/generate-graphviz.ps1
@@ -1,8 +1,8 @@
 Param(
-  [string] $barToken,
-  [string] $gitHubPat,
-  [string] $azdoPat,
-  [string] $outputFolder,
+  [Parameter(Mandatory=$true)][string] $barToken,
+  [Parameter(Mandatory=$true)][string] $gitHubPat,
+  [Parameter(Mandatory=$true)][string] $azdoPat,
+  [Parameter(Mandatory=$true)][string] $outputFolder,
   [string] $darcVersion = '1.1.0-beta.19154.2',
   [switch] $includeToolset
 )
@@ -27,13 +27,14 @@ try {
   CheckExitCode "Running darc-init"
 
   $DarcExe = "$env:USERPROFILE\.dotnet\tools"
-  $DarcExe = Resolve-Path $DarcExe
+  $DarcExe = Resolve-Path "$DarcExe\darc.exe"
   
   if (!(Test-Path -Path $outputFolder)) {
       Create-Directory $outputFolder
   }
-    
-  $options = "get-dependency-graph --graphviz '$outputFolder\graphviz.txt' --github-pat $gitHubPat --azdev-pat $azdoPat --password $barToken"
+  
+  $graphVizFilePath = "$outputFolder\graphviz.txt"
+  $options = "get-dependency-graph --graphviz '$graphVizFilePath' --github-pat $gitHubPat --azdev-pat $azdoPat --password $barToken"
   
   if ($includeToolset) {
     Write-Host "Toolsets will be included in the graph..."
@@ -41,10 +42,12 @@ try {
   }
 
   Write-Host "Generating dependency graph..."
-  $darc = Invoke-Expression "& `"$DarcExe\darc.exe`" $options"
-  $graph = Get-Content $outputFolder\graphviz.txt
-  Set-Content $outputFolder\graphviz.txt -Value "Paste the following digraph object in http://www.webgraphviz.com `r`n", $graph
-  Write-Host "'$outputFolder\graphviz.txt' file created!"
+  $darc = Invoke-Expression "& `"$DarcExe`" $options"
+  CheckExitCode "Generating dependency graph"
+  
+  $graph = Get-Content $graphVizFilePath
+  Set-Content $graphVizFilePath -Value "Paste the following digraph object in http://www.webgraphviz.com `r`n", $graph
+  Write-Host "'$graphVizFilePath' file created!"
 }
 catch {
   if (!$includeToolset) {

--- a/eng/common/generate-graphviz.ps1
+++ b/eng/common/generate-graphviz.ps1
@@ -1,10 +1,11 @@
 Param(
-  [Parameter(Mandatory=$true)][string] $barToken,
-  [Parameter(Mandatory=$true)][string] $gitHubPat,
-  [Parameter(Mandatory=$true)][string] $azdoPat,
-  [Parameter(Mandatory=$true)][string] $outputFolder,
-  [string] $darcVersion = '1.1.0-beta.19154.2',
-  [switch] $includeToolset
+  [Parameter(Mandatory=$true)][string] $barToken,       # Token generated at https://maestro-prod.westus2.cloudapp.azure.com/Account/Tokens
+  [Parameter(Mandatory=$true)][string] $gitHubPat,      # GitHub personal access token from https://github.com/settings/tokens (no auth scopes needed)
+  [Parameter(Mandatory=$true)][string] $azdoPat,        # Azure Dev Ops tokens from https://dev.azure.com/dnceng/_details/security/tokens (code read scope needed)
+  [Parameter(Mandatory=$true)][string] $outputFolder,   # Where the graphviz.txt file will be created
+  [string] $darcVersion = '1.1.0-beta.19154.2',         # darc's version
+  [switch] $includeToolset                              # Whether the graph should include toolset dependencies or not. i.e. arcade, optimization. For more about
+                                                        # toolset dependencies see https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md#toolset-vs-product-dependencies
 )
 
 $ErrorActionPreference = "Stop"
@@ -29,9 +30,7 @@ try {
   $DarcExe = "$env:USERPROFILE\.dotnet\tools"
   $DarcExe = Resolve-Path "$DarcExe\darc.exe"
   
-  if (!(Test-Path -Path $outputFolder)) {
-      Create-Directory $outputFolder
-  }
+  Create-Directory $outputFolder
   
   $graphVizFilePath = "$outputFolder\graphviz.txt"
   $options = "get-dependency-graph --graphviz '$graphVizFilePath' --github-pat $gitHubPat --azdev-pat $azdoPat --password $barToken"


### PR DESCRIPTION
With this change all the official builds will generate the GraphViz ready content so it can be copied and pasted in http://www.webgraphviz.com/ to look at everything which is contained in that given build. 

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=114089

In the test build you can see there a new leg at the very end and it will only run when all the OS build legs and the Publish to BAR leg have completed successfully.

You can find the generated file in Artifacts > Windows_NT_Graph > graphviz.txt (code in this PR will actually put it in  Artifacts > Graph > graphviz.txt

Note: I'm adding the script into eng/common since most likely this will be merged after Arcade has updated dependencies. Same script will be merged into Arcade's eng/common as well.

"skipciplease" 
