### PR TITLE
Set DOTNET_ROOT appropriately in internal build Init.cmd

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/Init.cmd
+++ b/src/redist/targets/packaging/windows/clisdk/Init.cmd
@@ -3,3 +3,14 @@
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set DOTNET_MULTILEVEL_LOOKUP=0
 set PATH=%~dp0;%PATH%
+
+if not "%PROCESSOR_ARCHITECTURE%"=="x86" goto :SetDotnetRoot_Wow
+if not "%PROCESSOR_ARCHITEW6432%"== "" goto :SetDotnetRoot_Wow
+
+:SetDotnetRoot
+set DOTNET_ROOT=%~dp0
+goto :eof
+
+:SetDotnetRoot_Wow
+set DOTNET_ROOT(x86)=%~dp0
+goto :eof


### PR DESCRIPTION
Fixes internal bug [817624](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/817624)

When running tests in the internal build environment, app hosts cannot find the runtime that comes from the VS.Tools.* package itself.

This sets DOTNET_ROOT (more commonly DOTNET_ROOT(x86) on 64-bit machines as this package is always x86) to the dotnet.exe directory provided by the VS.Tools package.