### PR TITLE
Don't exclude files starting with . from nupkgs

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/generatenupkg.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatenupkg.ps1
@@ -28,5 +28,5 @@ if (Test-Path $NupkgFile) {
     Remove-Item -Force $NupkgFile
 }
 
-& $NuGetExe pack $NuspecFile -Version $NugetVersion -OutputDirectory $OutputDirectory -NoPackageAnalysis -Properties DOTNET_BUNDLE=$SdkBundlePath
+& $NuGetExe pack $NuspecFile -Version $NugetVersion -OutputDirectory $OutputDirectory -NoDefaultExcludes -NoPackageAnalysis -Properties DOTNET_BUNDLE=$SdkBundlePath
 Exit $LastExitCode


### PR DESCRIPTION
This was preventing `dotnet --info` and `dotnet --version` from working
in internal build scenario.