### PR TITLE
Official Build break fix: remove project that is causing build break from solution

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Tools.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkResolver", "src\SdkResolver\SdkResolver.csproj", "{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Dotnet.Sdk.Internal", "src\Microsoft.Dotnet.Sdk.Internal\Microsoft.Dotnet.Sdk.Internal.csproj", "{939F85BD-0543-4AAA-A22A-DA42E90CD94F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,10 +43,6 @@ Global
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{939F85BD-0543-4AAA-A22A-DA42E90CD94F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{939F85BD-0543-4AAA-A22A-DA42E90CD94F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{939F85BD-0543-4AAA-A22A-DA42E90CD94F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{939F85BD-0543-4AAA-A22A-DA42E90CD94F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,7 +53,6 @@ Global
 		{53AF2D01-B69F-4CD0-86A7-8FD95967D23C} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{78E15EC1-7732-41E3-8591-934E9F583254} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
-		{939F85BD-0543-4AAA-A22A-DA42E90CD94F} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B526D2CE-EE2D-4AD4-93EF-1867D90FF1F5}


### PR DESCRIPTION
Quick fix for the build break while we find the proper solution on where to build and publish this fake package during the build process in #1140

Arcade SDK won't try to build the package since it won't be in the solution, and so it shouldn't ever be published.

@mmitche @livarcocc 
