### PR TITLE
Adding dependency for Microsoft.DotNet.Wpf.ProjectTemplates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -59,6 +59,10 @@
       <Sha>
       </Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0-preview4.19203.6">
+      <Uri>https://github.com/dotnet/wpf</Uri>
+      <Sha>a48d98b2b09a45e2828ae28e4d57e99261dde666</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19179.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotnetToolsetInternalPackageVersion>3.0.100-preview4.19181.5</MicrosoftDotnetToolsetInternalPackageVersion>
+    <MicrosoftDotNetWpfProjectTemplatesPackageVersion>3.0.0-preview4.19203.6</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/EntityFrameworkCore -->
@@ -58,7 +59,6 @@
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
     <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview4-27529-17</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
-    <MicrosoftDotnetWpfProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWpfProjectTemplatesPackageVersion>
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->


### PR DESCRIPTION
- skip ci please
- We just moved Microsoft.DotNet.Wpf.ProjectTemplates from dotnet-trusted to https://github.com/dotnet/wpf. 
- This dependency was added like this:

```
darc add-dependency -n Microsoft.DotNet.Wpf.ProjectTemplates -r https://github.com/dotnet/wpf -t product
darc update-dependencies -c ".NET Core 3 Dev" -n Microsoft.DotNet.Wpf.ProjectTemplates
Looking up latest build of https://github.com/dotnet/wpf on .NET Core 3 Dev
Updating 'Microsoft.DotNet.Wpf.ProjectTemplates': '' => '3.0.0-preview4.19203.6' (from build '20190403.6' of 'https://github.com/dotnet/wpf')
Checking for coherency updates...
Local dependencies updated from channel '.NET Core 3 Dev'.
```

There is also a new subscription added from dotnet/wpf => core-sdk for future upkeep on this package. 

```
darc get-subscriptions --source-repo wpf --target-repo core-sdk
https://github.com/dotnet/wpf (.NET Core 3 Dev) ==> 'https://github.com/dotnet/core-sdk' ('master')
  - Id: 2327f61b-891a-4b12-3ad1-08d6b8bc087e
  - Update Frequency: EveryDay
  - Enabled: True
  - Batchable: False
  - Merge Policies:
    AllChecksSuccessful
      ignoreChecks =
                     [
                       "'wip",
                       "license/cla'"
                     ]
```

/cc @zsd4yr, @nguerrera, @ericstj, @livarcocc 