### PR TITLE
adding new dependency on winforms for winforms template versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -55,6 +55,10 @@
       <Sha>
       </Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.WinForms.ProjectTemplates" Version="">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha></Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0-preview4.19203.6">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>a48d98b2b09a45e2828ae28e4d57e99261dde666</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -55,9 +55,9 @@
       <Sha>
       </Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.WinForms.ProjectTemplates" Version="">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-preview4.19205.5">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha></Sha>
+      <Sha>a875e24eff58bcc7a1bb124a6f05792639a83536</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0-preview4.19204.4">
       <Uri>https://github.com/dotnet/wpf</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotnetToolsetInternalPackageVersion>3.0.100-preview4.19181.5</MicrosoftDotnetToolsetInternalPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion></MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>3.0.0-preview4.19203.6</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -55,7 +56,6 @@
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
     <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview4-27604-2</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>$(MicrosoftWindowsDesktopPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotnetToolsetInternalPackageVersion>3.0.100-preview4.19205.4</MicrosoftDotnetToolsetInternalPackageVersion>
-    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion></MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+    <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>4.8.0-preview4.19205.5</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>3.0.0-preview4.19204.4</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotnetToolsetInternalPackageVersion>3.0.100-preview4.19205.6</MicrosoftDotnetToolsetInternalPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependency from https://github.com/dotnet/winforms -->
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>4.8.0-preview4.19205.5</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependency from https://github.com/dotnet/wpf -->
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>3.0.0-preview4.19204.4</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
* skip ci please

We just moved Microsoft.DotNet.WinForms.ProjectTemplates from dotnet-trusted to https://github.com/dotnet/winforms

Added dependency form winforms ➡️ core-sdk for `.NET Core 3 Dev` and `.NET Core 3 Release` channels
```cmd
PS E:\core-sdk> darc get-subscriptions --source-repo winforms --target-repo core-sdk
https://github.com/dotnet/winforms/ (.NET Core 3 Dev) ==> 'https://github.com/dotnet/core-sdk' ('master')
  - Id: a59eaf03-4e05-4e67-c451-08d6b9489d08
  - Update Frequency: everyDay
  - Merge Policies:
    AllChecksSuccessful
      ignoreChecks =
                     [
                       "'wip",
                       "license/cla'"
                     ]
  - Last Build: N/A
https://github.com/dotnet/winforms (.NET Core 3 Release) ==> 'https://github.com/dotnet/core-sdk' ('release/3.0.1xx')
  - Id: 4b5a32a1-5708-4933-c517-08d6b8b9770a
  - Update Frequency: everyBuild
  - Merge Policies:
    AllChecksSuccessful
      ignoreChecks =
                     [
                       "'wip",
                       "license/cla'"
                     ]
  - Last Build: N/A
```

also added the `.NET Core 3 Release` one for WPF, which was missing:

```cmd
PS E:\core-sdk> darc get-subscriptions --source-repo wpf --target-repo core-sdk --channel ".NET Core 3 Release"
https://github.com/dotnet/wpf (.NET Core 3 Release) ==> 'https://github.com/dotnet/core-sdk' ('release/3.0.1xx')
  - Id: e5282cf9-b4c6-4f8a-39b8-08d6b94bc833
  - Update Frequency: everyBuild
  - Merge Policies:
    AllChecksSuccessful
      ignoreChecks =
                     [
                       "'wip",
                       "license/cla'"
                     ]
  - Last Build: N/A
```

/cc @vatsan-madhavan , @nguerrera, @ericstj, @livarcocc