### PR TITLE
Switch to .Ref targeting pack for .NET Standard 2.1

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -231,9 +231,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               
      <KnownFrameworkReference Include="NETStandard.Library"
                               TargetFramework="netstandard2.1"
-                              TargetingPackName="NETStandard.Library"
+                              TargetingPackName="NETStandard.Library.Ref"
                               TargetingPackVersion="$(NETStandardLibraryRefPackageVersion)"
-                              TargetingPackFormat="NETStandardLegacy"
                               />
 
   </ItemGroup>


### PR DESCRIPTION
Should unblock failing test in https://github.com/dotnet/sdk/pull/3113