### PR TITLE
Updating the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/dotnet/cli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/cli?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repo contains the source code for the cross-platform [.NET Core](http://github.com/dotnet/core) SDK. It aggregates the .NET Toolchain, the .NET Core runtime, the templates, the offline packages cache, the ASP.NET Runtime store, and the .NET Core Windows Desktop runtime. It produces zip, tarballs, and native packages for various supported platforms.
+This repo contains the source code for the cross-platform [.NET Core](http://github.com/dotnet/core) SDK. It aggregates the .NET Toolchain, the .NET Core runtime, the templates, and the .NET Core Windows Desktop runtime. It produces zip, tarballs, and native packages for various supported platforms.
 
 Looking for V2 of the .NET Core tooling?
 ----------------------------------------


### PR DESCRIPTION
Description:

The offline packages cache and the ASP.NET Runtime store not in .NET Core SDK 3.0 anymore

cc: @dsplaisted @livarcocc 