### PR TITLE
Update apphost pack pattern

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -202,7 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"
                       TargetFramework="netcoreapp3.0"
-                      AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
+                      AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
                       AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                       />


### PR DESCRIPTION
Use new apphost pack name pattern: `Microsoft.NETCore.App.Host.**RID**` instead of `runtime.**RID**.Microsoft.NETCore.DotNetAppHost`