### PR TITLE
CI Updates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -54,6 +54,10 @@
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>ab24a5de1bf2d8b71eff678798b65bd562630ae2</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk" Version="3.0.100-preview5.19212.8">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>6916b50efb78f126aa68a5d183993f55fb6e03c9</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="3.0.100-preview5.19219.4">
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>6487f2fd7a2d9cb44bad72d6c36af289de2d721f</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,6 +44,10 @@
     <NUnit3TemplatesVersion>1.6.1</NUnit3TemplatesVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/sdk (to run tests) -->
+    <MicrosoftNETSdkPackageVersion>3.0.100-preview5.19212.8</MicrosoftNETSdkPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview5-27619-08</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -20,9 +20,7 @@ phases:
     name: ${{ parameters.agentOs }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true
-    enablePublishBuildArtifacts: true
     enablePublishBuildAssets: true
-    enablePublishTestResults: true
     enableTelemetry: true
     helixRepo: dotnet/core-sdk
     pool: ${{ parameters.pool }}
@@ -30,6 +28,7 @@ phases:
       strategy: ${{ parameters.strategy }}
 
     variables: 
+      - _AgentOSName: ${{ parameters.agentOs }}
       - _TeamName: Roslyn-Project-System
       - _BuildArgs: ''
       - _SignType: test
@@ -98,6 +97,36 @@ phases:
                   $(_BuildArgs)
                   $(_AdditionalBuildParameters)
         displayName: Build
+
+    - task: PublishTestResults@1	
+      displayName: Publish Test Results	
+      inputs:	
+        testRunner: XUnit	
+        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
+        testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
+        platform: '$(BuildPlatform)'	
+        configuration: '$(_BuildConfig)'	
+      condition: not(succeeded())
+
+    - task: CopyFiles@2	
+      displayName: Gather Logs	
+      inputs:	
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
+        Contents: |	
+         log/$(_BuildConfig)/**/*	
+         TestResults/$(_BuildConfig)/**/*	
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'	
+      continueOnError: true	
+      condition: not(succeeded())	
+
+    - task: PublishBuildArtifacts@1	
+      displayName: Publish Logs to VSTS	
+      inputs:	
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
+        ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
+        publishLocation: Container	
+      continueOnError: true	
+      condition: not(succeeded())
 
     - ${{ if and(eq(parameters.enablePublishBuildAssets, true), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: CopyFiles@2


### PR DESCRIPTION
- Include test results as part of build artifacts
- Set test run title and build artifact filename to correspond to leg it came from
- Add dependency on dotnet/sdk
  - This is separate from the other changes, but I'd like to get it in the repo so I don't keep having merge conflicts in #1454