### PR TITLE
Switch to  .Internal insertion package for .NET Core

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-05">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
+      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-05">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
+      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-05">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
+      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-17">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
+      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-17">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
+      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-17">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
+      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-08">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c0420903263f4d1812bab6c5bd6e5d1fff54adc</Sha>
+      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-08">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c0420903263f4d1812bab6c5bd6e5d1fff54adc</Sha>
+      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-08">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c0420903263f4d1812bab6c5bd6e5d1fff54adc</Sha>
+      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-12">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
+      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-12">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
+      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-12">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
+      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-02">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
+      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-02">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
+      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-02">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
+      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-15">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
+      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-15">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
+      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-15">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
+      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-14">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
+      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-14">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
+      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-14">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
+      <Sha>af6df5c0009bfd483b4c70313c0f020e2d43a5a9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-01">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
+      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-01">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
+      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-01">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
+      <Sha>080036780727e15ff59896cb62bc93c48161bf02</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-03">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
+      <Sha>a765e76a14bfd012c9efb8dbb5eba624a0f2efe8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-03">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
+      <Sha>a765e76a14bfd012c9efb8dbb5eba624a0f2efe8</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-03">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0e672068ffe4c062b8b70b48073429d20657fd1b</Sha>
+      <Sha>a765e76a14bfd012c9efb8dbb5eba624a0f2efe8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-02">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
+      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-02">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
+      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-02">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
+      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-12">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
+      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-12">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
+      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-12">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
+      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-06">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
+      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-06">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
+      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-06">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>caa43222ae617dfa2212b897ba07ed1022f58640</Sha>
+      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-16">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
+      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-16">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
+      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-16">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
+      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,15 +2,15 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-14">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-14">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-14">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-21">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
+      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-21">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
+      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-21">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
+      <Sha>75a361aef7e2a952c4d4324f0438c4ee4b4e4725</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-18">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27625-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
+      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-18">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27625-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
+      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-18">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27625-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67a906beec98f1049169a4a24266096668519a9d</Sha>
+      <Sha>30d899d1f6ad8a7e814d735cb8dc8869fe78de88</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-16">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
+      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-16">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
+      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-16">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>bcce001fbb6043b7bfded004f6e38f3b3f8b90c5</Sha>
+      <Sha>d65fb6409f0fc1977d11873fc2c100910ddc4b70</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-03">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
+      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-03">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
+      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-03">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>ab058d3c4212e08fd016076b677d8930a269eb2c</Sha>
+      <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,15 +2,15 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-04">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-04">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-04">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>a2406d8f4bba9541a850dbb1f941a5463cd2a74a</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-13">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
+      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-13">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
+      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-13">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67765e65e47a21f1b394828ebf02ab0c52985212</Sha>
+      <Sha>37feaa4bcc88668674fed44d88a118562a60ca90</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-09">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
+      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-09">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
+      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-09">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>15d9119611a2fac0714738b611c15f1cc9defe4c</Sha>
+      <Sha>c49e86a34ce6f6f5d49fcfedc79c93fbb5de921b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-15">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
+      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-15">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
+      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-15">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
+      <Sha>b874ecc6abf55cc155369cc6a9b28a7c5a20e9cc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-10">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
+      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-10">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
+      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-10">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f76da70021172d6712830d39a864e4648bf43e29</Sha>
+      <Sha>02bd615e1fb502cbc4944c4a1e13c2d5d3ccbed0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-13">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27624-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
+      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-13">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27624-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
+      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-13">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27624-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b18fa2e4c8b254c7455b8a8c8e1093d7593f9249</Sha>
+      <Sha>dc713e8923abbd66e67b93e3ebf9253632f98be1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-18">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-20">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
+      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-18">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-20">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
+      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-18">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-20">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f3d0e730d273b3d4fe98dca358d70cfc02ab431a</Sha>
+      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-20">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27623-21">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
+      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-20">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27623-21">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
+      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-20">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27623-21">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1af0881ca78d504e558f77419249b30ee0db66c7</Sha>
+      <Sha>b6b52431f0b84cc167596860cf9864ebaa9cc782</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19223-01">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-13</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-14</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-13</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-14</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-13</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-14</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-04</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-05</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-04</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-05</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-04</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-05</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-03</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-03</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-04</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-03</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-04</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-18</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-18</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-01</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-18</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-01</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-16</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-17</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-16</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-17</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-16</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-17</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-21</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-21</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-02</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-21</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-02</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-02</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-03</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-02</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-03</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-02</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-03</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-09</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-12</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-09</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-12</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-09</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-12</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-12</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-13</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-12</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-13</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-12</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-13</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-05</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-06</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-05</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-06</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-05</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-06</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-08</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-10</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-08</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-10</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-08</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-10</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-14</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-15</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-14</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-15</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-14</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-15</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-10</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-12</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-10</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-12</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-10</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-12</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-12</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-13</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-12</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-13</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-12</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-13</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-02</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-03</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-02</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-03</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-02</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-03</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-14</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-15</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-14</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-15</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-14</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-15</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-13</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-14</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-13</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-14</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-13</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-14</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-01</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-01</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27625-02</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-01</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27625-02</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-15</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-16</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-15</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-16</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-15</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-16</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-17</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-18</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-17</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-18</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-17</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-18</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-15</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-16</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-15</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-16</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-15</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-16</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,8 +49,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreDotNetAppHostPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreDotNetAppHostPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-18</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-20</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-18</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-20</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-18</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-20</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-16</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-18</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-16</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-18</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-16</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-18</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-20</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27623-21</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-20</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27623-21</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-20</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27623-21</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-09</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-06</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-09</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-06</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-09</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,17 +48,17 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19223.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-03</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27624-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-03</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27624-04</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-03</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27624-04</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,6 +49,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreDotNetAppHostPackageVersion>3.0.0-preview6-27625-04</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -4,7 +4,7 @@
           DependsOnTargets="SetSdkBrandingInfo">
     
     <PropertyGroup>
-      <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
+      <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app.internal</RuntimeNETCoreAppPackageName>
       <_crossDir Condition="'$(Architecture)' == 'arm64'">/x64_arm64</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">/x64_arm</_crossDir>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -42,8 +42,8 @@
     <ItemGroup>
       <MetaPackageDownload Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
         <Properties>
-          PackageToRestore=Microsoft.NETCore.App;
-          PackageVersionToRestore=$(MicrosoftNETCoreAppPackageVersion);
+          PackageToRestore=Microsoft.NETCore.App.Internal;
+          PackageVersionToRestore=$(MicrosoftNETCoreAppInternalPackageVersion);
           TargetFramework=$(TargetFramework)
         </Properties>
       </MetaPackageDownload>
@@ -61,7 +61,7 @@
       Projects="@(MetaPackageDownload)">
     </MSBuild>
 
-    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.netcore.app/$(MicrosoftNETCoreAppPackageVersion)">
+    <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.netcore.app.internal/$(MicrosoftNETCoreAppPackageVersion)">
       <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="NetCoreRuntimePackRids" />
     </GetRuntimePackRids>
     <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.windowsdesktop.app/$(MicrosoftWindowsDesktopPackageVersion)">
@@ -196,7 +196,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(NetCoreAppTargetingPackVersion)"
                               AppHostPackNamePattern="runtime.**RID**.Microsoft.NETCore.DotNetAppHost"
                               AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
-                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
+                              RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App.Internal%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                               RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               />
 

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -363,25 +363,12 @@
     
     <RemoveDir Directories="$(AppHostRestorePath)" />
     <MakeDir Directories="$(AppHostRestorePath)" />
-
-    <ItemGroup>
-      <NETCoreDotNetAppHostPackageVersions Include="@(PackageDefinitions->'%(Version)')"
-                                           Condition="%(PackageDefinitions.Name) == $(NETCoreDotNetAppHostPackageName)" />
-    </ItemGroup>
-
-    <Error Condition="@(NETCoreDotNetAppHostPackageVersions->Distinct()->Count()) != 1"
-           Text="Failed to determine the $(NETCoreDotNetAppHostPackageName) version pulled in Microsoft.NETCore.App" />
-
-    <PropertyGroup>
-      <_NETCoreDotNetAppHostPackageVersion>@(NETCoreDotNetAppHostPackageVersions->Distinct())</_NETCoreDotNetAppHostPackageVersion>
-    </PropertyGroup>
-
       
     <ItemGroup>
       <AppHostTemplateDownloadPackageProject Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
         <Properties>
           PackageToRestore=$(NETCoreDotNetAppHostPackageName);
-          PackageVersionToRestore=$(_NETCoreDotNetAppHostPackageVersion);
+          PackageVersionToRestore=$(MicrosoftNETCoreDotNetAppHostPackageVersion);
           TargetFramework=$(TargetFramework);
           RestorePackagesPath=$(AppHostRestorePath);
           RuntimeIdentifier=$(Rid)


### PR DESCRIPTION
React to changes in https://github.com/dotnet/core-setup/pull/5893: Switch to Microsoft.NETCore.App.Internal

Includes version updates from  #1712, and additional changes to switch to the .Internal package.

@dagood @mmitche Are the new `MicrosoftNETCoreAppInternalPackageVersion` and `MicrosoftNETCoreDotNetAppHostPackageVersion` properties set up so that they will be updated through the dependency flow?