### PR TITLE
Add PackagesToReference metadata to KnownFrameworkReference

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -190,6 +190,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                               RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
+                              PackagesToReference="Microsoft.NETCore.App/$(NetCoreAppTargetingPackVersion)"
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"


### PR DESCRIPTION
The SDK will consume this to generate PackageReferences to "empty" packages such as Microsoft.NETCore.App

@dagood 