### PR TITLE
make publish of internal dummy sdk asset conditional

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -57,6 +57,7 @@ jobs:
           _BuildArchitecture: x64
           _DOTNET_CLI_UI_LANGUAGE: ''
           _DropSuffix: ''
+          _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
         Build_Release_arm:
           _BuildConfig: Release
           _BuildArchitecture: arm

--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Tools.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkResolver", "src\SdkResolver\SdkResolver.csproj", "{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Dotnet.Sdk.Internal", "src\Microsoft.Dotnet.Sdk.Internal\Microsoft.Dotnet.Sdk.Internal.csproj", "{73F07908-981B-41BB-B9BD-F3420274A6F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.Dotnet.Sdk.Internal/Microsoft.Dotnet.Sdk.Internal.csproj
+++ b/src/Microsoft.Dotnet.Sdk.Internal/Microsoft.Dotnet.Sdk.Internal.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>true</IsPackable>
+    <IsPackable Condition="$(PublishInternalAsset) == true">true</IsPackable>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 


### PR DESCRIPTION
Another stab at https://github.com/dotnet/arcade/issues/2426
Make the IsPackable property in the dummy package conditionalized, and only pass that property during one of the build legs.


