### PR TITLE
Fix core-setup update: download consolidated dotnet-runtime-deps Deb pkg

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-09">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
+      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-09">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
+      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-09">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-10">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
+      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-05">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
+      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-05">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
+      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-05">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
+      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-12">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
+      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-12">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
+      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-12">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-13">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
+      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-19">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
+      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-19">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
+      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-19">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
+      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-13">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
+      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-13">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
+      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-13">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0c975c4ccbf3ff51913031be7e089aa70aad2318</Sha>
+      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-12">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
+      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-12">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
+      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-12">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-14">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
+      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-04">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
+      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-04">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
+      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-04">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
+      <Sha>81ecb7f47f82e7d1dc14d8a6823da21de7749691</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-17">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
+      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-17">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
+      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-17">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-18">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
+      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-11">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
+      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-11">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
+      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-11">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
+      <Sha>fb04004d80db66dc984f85fdd0cdcc4129f506c6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-06">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
+      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-06">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
+      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-06">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
+      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-14">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
+      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-14">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
+      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-14">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-01">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>92f55dca3e257d38dc7ad273625ab10a6f703af5</Sha>
+      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-05">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
+      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-05">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
+      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-05">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
+      <Sha>9932e9bc4ed6ac03cfdf794f3ec81729b7dde200</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-08">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
+      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-08">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
+      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-08">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
+      <Sha>84f6bc60cea0abbc8a784fd6f77c3645f99c2307</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,15 +2,15 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-15">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-15">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-15">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-08">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
+      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-08">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
+      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-08">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2df06d3d0f21a3cc2683bb227fb98c1901aa7405</Sha>
+      <Sha>c640b94244f4f94370fa2f65d97add9a64eb8698</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-11">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
+      <Sha>bf926d1830524fdfeedad55e7910b32c59448cb1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-11">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
+      <Sha>bf926d1830524fdfeedad55e7910b32c59448cb1</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-11">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
+      <Sha>bf926d1830524fdfeedad55e7910b32c59448cb1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-16">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
+      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-16">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
+      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-16">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-17">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
+      <Sha>8446939f389cfcb6876397698cafdee99b8a461e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-01">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
+      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-01">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
+      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-01">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>cc67037583762fd5ab3876dc5210c1a41bc42994</Sha>
+      <Sha>697fad336250b98dc81429e246fee5f15d85b71c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-07">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
+      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-07">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
+      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-07">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
+      <Sha>c28ee42e857a14d7647727a89c8f6aa84f0ce50c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-01">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
+      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-01">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
+      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-01">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-02">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>b0fcdbf454bc1c620fa698840ec0fa168bfd40fd</Sha>
+      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27629-07">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a3967b6096dc6a688f338d9eb4f986d537977c1e</Sha>
+      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27629-07">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a3967b6096dc6a688f338d9eb4f986d537977c1e</Sha>
+      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27629-07">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-08">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>a3967b6096dc6a688f338d9eb4f986d537977c1e</Sha>
+      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-10">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
+      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-10">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
+      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-10">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1f04f7007f2efe52d74e80e699c800a4aa384550</Sha>
+      <Sha>8d63c986c786a832a58c8927f575ad1739e94046</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-06">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27702-07">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
+      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-06">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27702-07">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
+      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-06">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27702-07">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>dadb168d6a2e80a5ad82a02ff17584abcb4475f9</Sha>
+      <Sha>2882fcdfd1846578a0c0336e1ba387ab0a1b602f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-04">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
+      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-04">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
+      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-04">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
+      <Sha>67d1e89736bfe5839c9f4291d43c5b6f0f5d686b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-11">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
+      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-11">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
+      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-11">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-12">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
+      <Sha>d3d13977d72c179019bb9eaec97e863af82a332b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-14">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
+      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-14">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
+      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-14">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-15">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>331076a7ea7a72afa659a119b1380681ee8b0b8f</Sha>
+      <Sha>c5eff03d4f9c0745bb4bcc088487ea8e89bb35a2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-02">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27703-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
+      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-02">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27703-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
+      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-02">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27703-04">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>45876af5c7a20db88da33f0fa46b987767951c13</Sha>
+      <Sha>eacd227fec04b19d3d69bbdcacdd542dadd4fa99</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-09">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
+      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-09">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
+      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-09">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
+      <Sha>3ef2938cabc7260c09565ed4f13bf9c88af2e79e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-08">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
+      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-08">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
+      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-08">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-09">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9d116002619579b034a063a08e7cf3ed5d9ef07a</Sha>
+      <Sha>e8c591e342d59ffc352e3eef8440c24344c74fec</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,17 +2,17 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-18">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="3.0.0-preview6-27701-19">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
+      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-18">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27701-19">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
+      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-18">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27701-19">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f72416f75497c376a1071d75379f51a6e02af21e</Sha>
+      <Sha>c0b89cbe52a1307782d34006f969b2095f643201</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview6-19230-05">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-04</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-05</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-04</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-05</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-04</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-05</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-07</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-08</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-07</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-08</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-07</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-08</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-14</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-14</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-01</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-14</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-01</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-01</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-01</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-04</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-01</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-04</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-11</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-12</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-11</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-12</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-11</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-12</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-09</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-10</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-09</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-10</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-09</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-10</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-09</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-11</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-09</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-11</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-09</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-11</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-15</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-16</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-15</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-16</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-15</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-16</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-12</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-14</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-12</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-14</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-12</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-14</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-05</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-06</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-05</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-06</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-05</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-06</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-17</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-18</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-17</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-18</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-17</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-18</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-08</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-11</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-08</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-11</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-08</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-11</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-08</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-09</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-08</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-09</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-08</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-09</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-13</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-14</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-13</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-14</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-13</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-14</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-12</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-13</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-12</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-13</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-12</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-13</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-08</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-06</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-08</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-06</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-08</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-02</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-02</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-04</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-02</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-04</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27629-07</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-08</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27629-07</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-08</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27629-07</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-08</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-08</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-09</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-08</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-09</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-08</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-09</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-11</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-12</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-11</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-12</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-11</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-12</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-18</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-19</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-18</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-19</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-18</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-19</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-11</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-12</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-11</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-12</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-11</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-12</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-01</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-01</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-02</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-01</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-02</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-10</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-11</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-10</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-11</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-10</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-11</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-05</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27703-06</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-05</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27703-06</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-05</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27703-06</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-19</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-19</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-01</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-19</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-01</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-16</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-17</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-16</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-17</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-16</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-17</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-14</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27701-15</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-14</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27701-15</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-14</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27701-15</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-06</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-07</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-06</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-07</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-06</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-07</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNETSdkPackageVersion>3.0.100-preview6.19230.1</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-04</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27702-05</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetAppHostPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
@@ -56,11 +56,11 @@
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-04</NETStandardLibraryRefPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27702-05</NETStandardLibraryRefPackageVersion>
     <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-04</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview6-27702-05</MicrosoftWindowsDesktopAppPackageVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -18,15 +18,19 @@
       <InstallerStartSuffix Condition="'$(HostOSName)' == 'osx'">-internal</InstallerStartSuffix>
 
       <!-- Downloaded Installers + Archives -->
-      <DownloadedRuntimeDepsInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime-deps-$(SharedHostVersion)-$(CoreSetupRid)$(InstallerExtension)</DownloadedRuntimeDepsInstallerFileName>
 
       <!-- Use the "x64" Rid when downloading Linux shared framework 'DEB' installer files. -->
       <SharedFrameworkInstallerFileRid>$(CoreSetupRid)</SharedFrameworkInstallerFileRid>
       <SharedFrameworkInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true' ">x64</SharedFrameworkInstallerFileRid>
 
+      <!-- Use the "x64" Rid when downloading Linux runtime dependencies Debian package. -->
+      <RuntimeDepsInstallerFileRid>$(CoreSetupRid)</RuntimeDepsInstallerFileRid>
+      <RuntimeDepsInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' ">x64</RuntimeDepsInstallerFileRid>
+
       <DownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host$(InstallerStartSuffix)-$(SharedHostVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedHostInstallerFileName>
       <DownloadedHostFxrInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-hostfxr$(InstallerStartSuffix)-$(HostFxrVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedHostFxrInstallerFileName>
       <DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime$(InstallerStartSuffix)-$(MicrosoftNETCoreAppPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
+      <DownloadedRuntimeDepsInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime-deps-$(SharedHostVersion)-$(RuntimeDepsInstallerFileRid)$(InstallerExtension)</DownloadedRuntimeDepsInstallerFileName>
       <DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">windowsdesktop-runtime-$(MicrosoftWindowsDesktopPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName>
       <DownloadedNetCoreAppTargetingPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-targeting-pack-$(NetCoreAppTargetingPackVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedNetCoreAppTargetingPackInstallerFileName>
       <DownloadedNetCoreAppHostPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-apphost-pack-$(NetCoreAppHostPackVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedNetCoreAppHostPackInstallerFileName>


### PR DESCRIPTION
Applies fixes on top of https://github.com/dotnet/core-sdk/pull/1825 described at https://github.com/dotnet/core-sdk/pull/1825#issuecomment-489139653.

/cc @davidfowl @billwert @brianrob 