### PR TITLE
Mark Microsoft.NETCore.App as trimmable

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -191,6 +191,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.NETCore.App%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostResolver%3Bruntime.**RID**.Microsoft.NETCore.DotNetHostPolicy"
                               RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
                               PackagesToReference="Microsoft.NETCore.App/$(NetCoreAppTargetingPackVersion)"
+                              IsTrimmable="true"
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"


### PR DESCRIPTION
The SDK will be updated to flow this metadata to resolved dlls,
influencing the default linker behavior.
@dsplaisted @nguerrera 
