### PR TITLE
Versions of WPF and Winforms Templates should be routed through Versions from Core Setup

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,11 +62,11 @@
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>f4954f490fe13267125ed3e84fcceba52007dd8d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-preview6.19260.11">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-preview6.19260.11" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>e0ae5fa739d27ad4524024be51885d58445f1c74</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0-preview6.19262.3">
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0-preview6.19262.3" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>50c1722341e347760aa3bf5d9a86c1de7cf4dca7</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,6 +62,7 @@
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>f4954f490fe13267125ed3e84fcceba52007dd8d</Sha>
     </Dependency>
+    <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via core setup -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-preview6.19260.11" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>e0ae5fa739d27ad4524024be51885d58445f1c74</Sha>


### PR DESCRIPTION
Winforms and WPF send their project templates straight to the SDK while our binaries are sent to the SDK via core-setup. For coherency purposes, these should wait to update until winforms and wpf have been routed via core setup as well.

/cc @mmitche @vatsan-madhavan @AdamYoblick 
