### PR TITLE
Remove dotnet-sql-cache from the CLI

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,10 +30,6 @@
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
       <Sha>4a2bd2adbf74b316f01eb062de3e83261562801d</Sha>
     </Dependency>
-    <Dependency Name="dotnet-sql-cache" Version="3.0.0-preview6-19265-02">
-      <Uri>https://github.com/aspnet/AspNetCore</Uri>
-      <Sha>4a2bd2adbf74b316f01eb062de3e83261562801d</Sha>
-    </Dependency>
     <Dependency Name="dotnet-user-secrets" Version="3.0.0-preview6-19265-02">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
       <Sha>4a2bd2adbf74b316f01eb062de3e83261562801d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,6 @@
     <MicrosoftAspNetCoreAppRefPackageVersion>3.0.0-preview6-19265-02</MicrosoftAspNetCoreAppRefPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview6-19265-02</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <dotnetdevcertsPackageVersion>3.0.0-preview6-19265-02</dotnetdevcertsPackageVersion>
-    <dotnetsqlcachePackageVersion>3.0.0-preview6-19265-02</dotnetsqlcachePackageVersion>
     <dotnetusersecretsPackageVersion>3.0.0-preview6-19265-02</dotnetusersecretsPackageVersion>
     <dotnetwatchPackageVersion>3.0.0-preview6-19265-02</dotnetwatchPackageVersion>
   </PropertyGroup>

--- a/src/redist/targets/BundledDotnetTools.targets
+++ b/src/redist/targets/BundledDotnetTools.targets
@@ -1,7 +1,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <BundledDotnetTool Include="dotnet-dev-certs" Version="$(DotnetDevCertsPackageVersion)" />
-    <BundledDotnetTool Include="dotnet-sql-cache" Version="$(DotnetSqlCachePackageVersion)" ObsoletesCliTool="Microsoft.Extensions.Caching.SqlConfig.Tools" />
     <BundledDotnetTool Include="dotnet-user-secrets" Version="$(DotnetUserSecretsPackageVersion)" ObsoletesCliTool="Microsoft.Extensions.SecretManager.Tools" />
     <BundledDotnetTool Include="dotnet-watch" Version="$(DotnetWatchPackageVersion)" ObsoletesCliTool="Microsoft.DotNet.Watcher.Tools" />
   </ItemGroup>


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/3752 

This tool has a dependency on SqlClient which is not fully open-source. As a result, we can't make this tool part of source-build for ASP.NET Core. As this tool has fairly low usage, we would like to change this tool ship as an out-of-box global tool package. 

This PR removes dotnet-sql-cache as a first-class, bundled command from the CLI.

cc @divega @DamianEdwards @Pilchie @KathleenDollard 