### PR TITLE
Re-enable mvc tests

### DIFF
--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -111,8 +111,7 @@ namespace EndToEnd.Tests
         [InlineData("mstest")]
         [InlineData("nunit")]
         [InlineData("web")]
-        //  Disable mvc template due to https://github.com/aspnet/AspNetCore/issues/10218
-        // [InlineData("mvc")]
+        [InlineData("mvc")]
         public void ItCanBuildTemplates(string templateName)
         {
             TestTemplateBuild(templateName);


### PR DESCRIPTION
It was reported on https://github.com/dotnet/sdk/issues/3245 that the latest build is working, so re-enable the test

Fix #2035 