### PR TITLE
Remove Windows Desktop project templates for non-Windows.

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -26,6 +26,11 @@
   </ItemGroup>
 
   <Target Name="LayoutTemplates" DependsOnTargets="SetupBundledComponents">
+    <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
+      <BundledTemplate Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
+      <BundledTemplate Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
+    </ItemGroup>
+
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
           DestinationFolder="$(SdkOutputDirectory)Templates/"/>
   </Target>

--- a/test/EndToEnd/GivenUnixPlatform.cs
+++ b/test/EndToEnd/GivenUnixPlatform.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace EndToEnd.Tests
+{
+    public class GivenUnixPlatform : TestBase
+    {
+        [UnixOnlyTheory]
+        [InlineData("wpf")]
+        [InlineData("winforms")]
+        public void ItDoesNotIncludeWindowsOnlyProjectTemplates(string template)
+        {
+            var directory = TestAssets.CreateTestDirectory();
+
+            new NewCommandShim()
+                .WithWorkingDirectory(directory.FullName)
+                .Execute(template)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($": {template}.");
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/UnixOnlyTheoryAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/UnixOnlyTheoryAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class UnixOnlyTheoryAttribute : TheoryAttribute
+    {
+        public UnixOnlyTheoryAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                this.Skip = "This test requires Unix to run";
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR removes the Windows Desktop project templates for non-Windows
builds of the .NET Core SDK.

Fixes dotnet/cli#11425.