### PR TITLE
Update Microsoft.WindowsDesktop.App to mark as "Windows only".

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -211,6 +211,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(WindowsDesktopTargetingPackVersion)"
                               RuntimePackNamePatterns="runtime.**RID**.Microsoft.WindowsDesktop.App"
                               RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
+                              IsWindowsOnly="true"
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"


### PR DESCRIPTION
This PR marks the `Microsoft.WindowsDesktop.App` known framework reference
as Windows only.  This will be used by a upcoming SDK change to ensure that
"Windows only" frameworks can only be used on Windows.