### PR TITLE
Exclude sdk resolver layout from source build

### DIFF
--- a/src/SdkResolver/SdkResolver.csproj
+++ b/src/SdkResolver/SdkResolver.csproj
@@ -7,6 +7,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateRuntimeCofigurationFiles>false</GenerateRuntimeCofigurationFiles>
     <AssemblyName>UNUSED</AssemblyName>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/11459

