### PR TITLE
[master] Remove unused NETStandard.Library

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,10 +46,6 @@
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>cec9009be8cbd658f49d539ffc65650de26b6abb</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19303.1">
-      <Uri>https://github.com/dotnet/standard</Uri>
-      <Sha>c40f794cfbeda7b48122b930131188594d5dcc77</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="3.0.100-preview6.19281.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>2091d9e3d25dee185dcedf5cb0c2798837dd3a8d</Sha>


### PR DESCRIPTION
Unused and per-empted by NETStandard.Library.Ref

- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
