### PR TITLE
[release/3.0.1xx] Remove unused NETStandard.Library dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,10 +46,6 @@
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>966c7f394f6b67e10e2474d990f1f25b7b173780</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19302.1">
-      <Uri>https://github.com/dotnet/standard</Uri>
-      <Sha>5b593e7bb6f4f213c5b324f36c05c7581a1a3222</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="3.0.100-preview6.19303.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>9a92095d8ad0112291573385dc8f67adfdfe9322</Sha>


### PR DESCRIPTION
- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
