### PR TITLE
Publish the internal dummy package used by dependency flow using Arcade.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,8 +10,11 @@ variables:
   value: https://dotnetcli.blob.core.windows.net/dotnet/index.json
 - name: _PublishChecksumsBlobFeedUrl
   value: https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json
+- name: _ArcadePublishBlobFeedUrl
+  value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
+  - group: DotNet-Blob-Feed
 
 jobs:
 - template: /eng/build.yml
@@ -57,7 +60,9 @@ jobs:
           _BuildArchitecture: x64
           _DOTNET_CLI_UI_LANGUAGE: ''
           _DropSuffix: ''
-          _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+          _AdditionalBuildParameters: '/p:PublishInternalAsset=true
+            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+            /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)'
         Build_Release_arm:
           _BuildConfig: Release
           _BuildArchitecture: arm

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -62,7 +62,7 @@ jobs:
           _DropSuffix: ''
           _AdditionalBuildParameters: '/p:PublishInternalAsset=true
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-            /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)'
+            /p:DotNetPublishBlobFeedUrl=$(_ArcadePublishBlobFeedUrl)'
         Build_Release_arm:
           _BuildConfig: Release
           _BuildArchitecture: arm

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,7 +12,6 @@
     <ChecksumsAccountKey>$(DotNetPublishChecksumsBlobFeedKey)</ChecksumsAccountKey>
     <SdkAssetsFeedUrl>$(DotnetPublishSdkAssetsBlobFeedUrl)</SdkAssetsFeedUrl>
     <SdkAssetsAzureAccountKey>$(DotNetPublishSdkAssetsBlobFeedKey)</SdkAssetsAzureAccountKey>
-
     <PublishSdkAssetsAndChecksumsToBlob>false</PublishSdkAssetsAndChecksumsToBlob>
     <PublishSdkAssetsAndChecksumsToBlob Condition=" '$(ChecksumsFeedUrl)' != '' and '$(SdkAssetsFeedUrl)' != '' ">true</PublishSdkAssetsAndChecksumsToBlob>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,6 +12,7 @@
     <ChecksumsAccountKey>$(DotNetPublishChecksumsBlobFeedKey)</ChecksumsAccountKey>
     <SdkAssetsFeedUrl>$(DotnetPublishSdkAssetsBlobFeedUrl)</SdkAssetsFeedUrl>
     <SdkAssetsAzureAccountKey>$(DotNetPublishSdkAssetsBlobFeedKey)</SdkAssetsAzureAccountKey>
+
     <PublishSdkAssetsAndChecksumsToBlob>false</PublishSdkAssetsAndChecksumsToBlob>
     <PublishSdkAssetsAndChecksumsToBlob Condition=" '$(ChecksumsFeedUrl)' != '' and '$(SdkAssetsFeedUrl)' != '' ">true</PublishSdkAssetsAndChecksumsToBlob>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,7 +8,6 @@
     <Product>Sdk</Product>
     <BlobStoragePartialRelativePath>$(Product)</BlobStoragePartialRelativePath>
     <BlobStoragePartialRelativePath Condition="'$(IsNotOrchestratedPublish)' == 'false'">assets/$(Product)</BlobStoragePartialRelativePath>
-    <PublishToBlobFeedFlatContainer>true</PublishToBlobFeedFlatContainer>
     <ChecksumsFeedUrl>$(DotnetPublishChecksumsBlobFeedUrl)</ChecksumsFeedUrl>
     <ChecksumsAccountKey>$(DotNetPublishChecksumsBlobFeedKey)</ChecksumsAccountKey>
     <SdkAssetsFeedUrl>$(DotnetPublishSdkAssetsBlobFeedUrl)</SdkAssetsFeedUrl>


### PR DESCRIPTION
Should finally fix https://github.com/dotnet/arcade/issues/2426

The leg that publishes the internal dummy package now additionally publishes via Arcade. The feed used is different to prevent collisions with the custom publishing already in place, and there will be no interference between the two.

CC/ @livarcocc @nguerrera 

