### PR TITLE
Remove PackagesToReference metadata from Microsoft.NETCore.App KnownFrameworkReference

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -190,7 +190,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(NetCoreAppTargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
-                              PackagesToReference="Microsoft.NETCore.App/$(NetCoreAppTargetingPackVersion)"
                               IsTrimmable="true"
                               />
 


### PR DESCRIPTION
Don't merge until https://github.com/dotnet/sdk/pull/3406 has been merged and flowed back into core-sdk.