### PR TITLE
Fix pt-BR translation of "runtime"

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -51,9 +51,9 @@
 
 O seguinte foi instalado em: '[DOTNETHOME]'
     • SDK do .NET Core [DOTNETSDKVERSION]
-    • Tempo de Execução do .NET Core [DOTNETRUNTIMEVERSION]
-    • Tempo de Execução do ASP.NET Core [ASPNETCOREVERSION]
-    • Tempo de Execução da Área de Trabalho do .NET Core Windows [WINFORMSANDWPFVERSION]
+    • Ambiente de Execução do .NET Core [DOTNETRUNTIMEVERSION]
+    • Ambiente de Execução do ASP.NET Core [ASPNETCOREVERSION]
+    • Ambiente de Execução da Área de Trabalho do .NET Core Windows [WINFORMSANDWPFVERSION]
 
 Este produto coleta dados de uso
     • Para obter mais informações e recusar, acesse https://aka.ms/dotnet-cli-telemetry


### PR DESCRIPTION
skipci

The correct translation for "runtime" in this context is "ambiente de execução".

/cc @mairaw