### PR TITLE
Generate a MSI for templates and move templates to dotnet/Templates

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -5,7 +5,8 @@
       <MicrosoftNETCoreAppVersionPreReleaseSeparator>$(MicrosoftNETCoreAppPackageVersion.IndexOf('-'))</MicrosoftNETCoreAppVersionPreReleaseSeparator>
       <MicrosoftNETCoreAppMajorMinorPatchVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppMajorMinorPatchVersion>
       <MicrosoftNETCoreAppMajorMinorPatchVersion Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppPackageVersion.Substring(0, $(MicrosoftNETCoreAppVersionPreReleaseSeparator)))</MicrosoftNETCoreAppMajorMinorPatchVersion>
-      <BundledTemplatesVersion>$(MicrosoftNETCoreAppMajorMinorPatchVersion)-$(VersionSuffix)</BundledTemplatesVersion>
+      <BundledTemplatesVersion>$(MicrosoftNETCoreAppMajorMinorPatchVersion)</BundledTemplatesVersion>
+      <BundledTemplatesVersion Condition=" '$(DropSuffix)' != 'true' And '$(VersionSuffix)' != '' ">$(BundledTemplatesVersion)-$(VersionSuffix)</BundledTemplatesVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -42,13 +42,13 @@
       <BundledTemplate Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplatesVersion)"/>
+          DestinationFolder="$(RedistLayoutPath)Templates/$(BundledTemplatesVersion)"/>
   </Target>
 
   <Target Name="LayoutTemplatesForMSI"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersion"
           Condition="$(ProductMonikerRid.StartsWith('win'))">
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
-          DestinationFolder="$(TemplatesLayoutPath)templates/$(BundledTemplatesVersion)"/>
+          DestinationFolder="$(TemplatesLayoutPath)Templates/$(BundledTemplatesVersion)"/>
   </Target>
 </Project>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -1,4 +1,14 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CalculateTemplatesVersion"
+          DependsOnTargets="SetSdkVersionInfo">
+    <PropertyGroup>
+      <MicrosoftNETCoreAppVersionPreReleaseSeparator>$(MicrosoftNETCoreAppPackageVersion.IndexOf('-'))</MicrosoftNETCoreAppVersionPreReleaseSeparator>
+      <MicrosoftNETCoreAppMajorMinorPatchVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppMajorMinorPatchVersion>
+      <MicrosoftNETCoreAppMajorMinorPatchVersion Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppPackageVersion.Substring(0, $(MicrosoftNETCoreAppVersionPreReleaseSeparator)))</MicrosoftNETCoreAppMajorMinorPatchVersion>
+      <BundledTemplatesVersion>$(MicrosoftNETCoreAppMajorMinorPatchVersion)-$(VersionSuffix)</BundledTemplatesVersion>
+    </PropertyGroup>
+  </Target>
+
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(MicrosoftDotNetCommonItemTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)" />
@@ -25,13 +35,20 @@
     </BundledTemplate>
   </ItemGroup>
 
-  <Target Name="LayoutTemplates" DependsOnTargets="SetupBundledComponents">
+  <Target Name="LayoutTemplates"
+          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersion">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
       <BundledTemplate Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
       <BundledTemplate Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
-
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
-          DestinationFolder="$(SdkOutputDirectory)Templates/"/>
+          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplatesVersion)"/>
+  </Target>
+
+  <Target Name="LayoutTemplatesForMSI"
+          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersion"
+          Condition="$(ProductMonikerRid.StartsWith('win'))">
+    <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
+          DestinationFolder="$(TemplatesLayoutPath)templates/$(BundledTemplatesVersion)"/>
   </Target>
 </Project>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -42,13 +42,13 @@
       <BundledTemplate Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)Templates/$(BundledTemplatesVersion)"/>
+          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplatesVersion)"/>
   </Target>
 
   <Target Name="LayoutTemplatesForMSI"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersion"
           Condition="$(ProductMonikerRid.StartsWith('win'))">
     <Copy SourceFiles="%(BundledTemplate.RestoredNupkgPath)"
-          DestinationFolder="$(TemplatesLayoutPath)Templates/$(BundledTemplatesVersion)"/>
+          DestinationFolder="$(TemplatesLayoutPath)templates/$(BundledTemplatesVersion)"/>
   </Target>
 </Project>

--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -83,7 +83,7 @@
       <ManpagesDirectory>$(RepoRoot)Documentation/manpages</ManpagesDirectory>
       <EndToEndTestProject>$(RepoRoot)test/EndToEnd/EndToEnd.Tests.csproj</EndToEndTestProject>
       <CLISdkRoot>$(RedistLayoutPath)sdk/</CLISdkRoot>
-      <TemplatesRoot>$(RedistLayoutPath)Templates/</TemplatesRoot>
+      <TemplatesRoot>$(RedistLayoutPath)templates/</TemplatesRoot>
     </PropertyGroup>
 
     <ItemGroup>
@@ -252,7 +252,7 @@
 
       <!-- Create layout: Templates -->
       <Copy
-        DestinationFiles="@(TemplatesFiles->'$(LayoutPackageRootDir)/Templates/%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(TemplatesFiles->'$(LayoutPackageRootDir)/templates/%(RecursiveDir)%(Filename)%(Extension)')"
         SourceFiles="@(TemplatesFiles)"
         OverwriteReadOnlyFiles="True"
         SkipUnchangedFiles="False"

--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -83,10 +83,12 @@
       <ManpagesDirectory>$(RepoRoot)Documentation/manpages</ManpagesDirectory>
       <EndToEndTestProject>$(RepoRoot)test/EndToEnd/EndToEnd.Tests.csproj</EndToEndTestProject>
       <CLISdkRoot>$(RedistLayoutPath)sdk/</CLISdkRoot>
+      <TemplatesRoot>$(RedistLayoutPath)Templates/</TemplatesRoot>
     </PropertyGroup>
 
     <ItemGroup>
-      <CLISdkFiles Include="$(CLISdkRoot)/**/*" />
+      <CLISdkFiles Include="$(CLISdkRoot)**/*" />
+      <TemplatesFiles Include="$(TemplatesRoot)**/*" />
       <SdkDebManPageFiles Include="$(ManpagesDirectory)/**/*" />
     </ItemGroup>
 
@@ -227,7 +229,7 @@
       DependsOnTargets="PrepareDotnetDebDirectories;
                         PrepareDotnetDebTool;
                         GetAspNetSharedFxInstallArgs;"
-      Inputs="@(CLISdkFiles)"
+      Inputs="@(CLISdkFiles);@(TemplatesFiles)"
       Outputs="$(SdkDebInstallerFile)" >
       <!-- Install Shared Framework Packages -->
       <Exec Command="sudo dpkg -i $(DownloadedNetCoreAppHostPackInstallerFile)" />
@@ -244,6 +246,14 @@
       <Copy
         DestinationFiles="@(CLISdkFiles->'$(LayoutPackageRootDir)/sdk/%(RecursiveDir)%(Filename)%(Extension)')"
         SourceFiles="@(CLISdkFiles)"
+        OverwriteReadOnlyFiles="True"
+        SkipUnchangedFiles="False"
+        UseHardlinksIfPossible="False" />
+
+      <!-- Create layout: Templates -->
+      <Copy
+        DestinationFiles="@(TemplatesFiles->'$(LayoutPackageRootDir)/Templates/%(RecursiveDir)%(Filename)%(Extension)')"
+        SourceFiles="@(TemplatesFiles)"
         OverwriteReadOnlyFiles="True"
         SkipUnchangedFiles="False"
         UseHardlinksIfPossible="False" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RedistLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet\</RedistLayoutPath>
     <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet-internal\</SdkInternalLayoutPath>
+    <TemplatesLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet-templates\</TemplatesLayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>
   </PropertyGroup>
   
@@ -415,6 +416,7 @@
                             GenerateBundledVersions;
                             LayoutRuntimeGraph;
                             LayoutTemplates;
+                            LayoutTemplatesForMSI;
                             LayoutBundledTools;
                             RetargetTools;
                             CrossgenLayout;

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -16,11 +16,14 @@
 
       <SdkGenerateMsiPowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatemsi.ps1</SdkGenerateMsiPowershellScript>
       <SdkStableFileIdForApphostTransform>$(MSBuildThisFileDirectory)packaging/windows/clisdk/stablefileidforapphosttransform.xslt</SdkStableFileIdForApphostTransform>
+      <TemplatesGenerateMsiPowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatetemplatesmsi.ps1</TemplatesGenerateMsiPowershellScript>
       <SdkGenerateBundlePowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatebundle.ps1</SdkGenerateBundlePowershellScript>
       <GenerateNupkgPowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatenupkg.ps1</GenerateNupkgPowershellScript>
 
       <ToolsetInstallerNuspecFile>$(MSBuildThisFileDirectory)packaging/windows/clisdk/VS.Redist.Common.NetCore.Toolset.nuspec</ToolsetInstallerNuspecFile>
       <ToolsetInstallerNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Toolset.$(Architecture).$(FullNugetVersion).nupkg</ToolsetInstallerNupkgFile>
+      <TemplatesInstallerNuspecFile>$(MSBuildThisFileDirectory)packaging/windows/clisdk/VS.Redist.Common.NetCore.Templates.nuspec</TemplatesInstallerNuspecFile>
+      <TemplatesInstallerNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(Architecture).$(FullNugetVersion).nupkg</TemplatesInstallerNupkgFile>
       <VSToolsNuspecFile>$(MSBuildThisFileDirectory)packaging/windows/clisdk/VS.Tools.Net.Core.SDK.nuspec</VSToolsNuspecFile>
       <VSToolsNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Tools.Net.Core.SDK.$(Architecture).$(FullNugetVersion).nupkg</VSToolsNupkgFile>
 
@@ -36,6 +39,8 @@
     <PropertyGroup>
       <SdkMSIInstallerFile>$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionSdk)$(InstallerExtension)</SdkMSIInstallerFile>
       <SdkMSICabFile>$(ArtifactsShippingPackagesDir)d$(Architecture)-1.cab</SdkMSICabFile>
+      <TemplatesMSIInstallerFile>$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionTemplates)$(InstallerExtension)</TemplatesMSIInstallerFile>
+      <TemplatesMSICabFile>$(ArtifactsShippingPackagesDir)t$(Architecture)-1.cab</TemplatesMSICabFile>
       <CombinedFrameworkSdkHostMSIInstallerFile>$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(BundleExtension)</CombinedFrameworkSdkHostMSIInstallerFile>
       <SdkBundleInstallerOutputGuidString>$(ProductBandCombinedHostHostFxrFrameworkSdkName)</SdkBundleInstallerOutputGuidString>
 
@@ -49,15 +54,9 @@
 
   <Target Name="MsiTargetsSetupInputOutputs"
           DependsOnTargets="GenerateLayout;SetupWixProperties;GetCoreSdkGitCommitInfo">
-    <!-- Generate SDK MSI Inputs -->
-    <ItemGroup>
-      <GenerateSdkMsiInputs Include="$(SdkInternalLayoutPath)**/*;
-                                       $(SdkGenerateMsiPowershellScript)" />
-    </ItemGroup>
-
     <!-- Consumed By Publish -->
     <ItemGroup>
-      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile)" />
+      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(TemplatesMSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile)" />
     </ItemGroup>
 
     <GenerateMsiVersion CommitCount="$(GitCommitCount)"
@@ -70,6 +69,11 @@
     <GenerateGuidFromName Name="$(SdkMSIInstallerFile)">
       <Output TaskParameter="OutputGuid"
           PropertyName="SdkInstallerUpgradeCode" />
+    </GenerateGuidFromName>
+
+    <GenerateGuidFromName Name="$(TemplatesMSIInstallerFile)">
+      <Output TaskParameter="OutputGuid"
+          PropertyName="TemplatesInstallerUpgradeCode" />
     </GenerateGuidFromName>
 
     <GenerateGuidFromName Name="$(SdkBundleInstallerOutputGuidString)">
@@ -104,8 +108,9 @@
 
   <Target Name="GenerateSdkMsi"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo"
-          Condition=" '$(OS)' == 'Windows_NT'"
-          Inputs="@(GenerateSdkMsiInputs)"
+          Condition=" '$(OS)' == 'Windows_NT' "
+          Inputs="$(SdkInternalLayoutPath)**/*;
+                    $(SdkGenerateMsiPowershellScript)"
           Outputs="$(SdkMSIInstallerFile)">
 
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript) ^
@@ -122,9 +127,29 @@
                       -InformationAction Continue" />
   </Target>
 
+  <Target Name="GenerateTemplatesMsi"
+        DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo"
+        Condition=" '$(OS)' == 'Windows_NT' "
+        Inputs="$(TemplatesLayoutPath)**/*;
+                  $(TemplatesGenerateMsiPowershellScript)"
+        Outputs="$(TemplatesMSIInstallerFile)">
+
+    <Exec Command="powershell -NoProfile -NoLogo $(TemplatesGenerateMsiPowershellScript) ^
+                      '$(TemplatesLayoutPath.TrimEnd('\'))' ^
+                      '$(TemplatesMSIInstallerFile)' ^
+                      '$(WixRoot)' ^
+                      '$(SdkBrandName)' ^
+                      '$(MsiVersion)' ^
+                      '$(SDKBundleVersion)' ^
+                      '$(NugetVersion)' ^
+                      '$(TemplatesInstallerUpgradeCode)' ^
+                      '$(Architecture)' ^
+                      -InformationAction Continue" />
+  </Target>
+
   <Target Name="GenerateSdkBundle"
-          DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi"
-          Condition=" '$(OS)' == 'Windows_NT'"
+          DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi;GenerateTemplatesMsi;SignTemplatesMsi"
+          Condition=" '$(OS)' == 'Windows_NT' "
           Inputs="$(SdkMSIInstallerFile);
                     $(DownloadedSharedFrameworkInstallerFile);
                     $(DownloadedHostFxrInstallerFile);
@@ -144,6 +169,7 @@
                       '$(DownloadsFolder)$(DownloadedNetCoreAppHostPackInstallerFileName)' ^
                       '$(DownloadsFolder)$(DownloadedAspNetTargetingPackInstallerFileName)' ^
                       '$(DownloadsFolder)$(DownloadedWindowsDesktopTargetingPackInstallerFileName)' ^
+                      '$(TemplatesMSIInstallerFile)' ^
                       '$(CombinedFrameworkSdkHostMSIInstallerFile)' ^
                       '$(WixRoot)' ^
                       '$(SdkBrandName)' ^
@@ -161,7 +187,7 @@
 
   <Target Name="GenerateToolsetNupkg"
           DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi"
-          Condition=" '$(OS)' == 'Windows_NT'"
+          Condition=" '$(OS)' == 'Windows_NT' "
           Inputs="$(SdkMSIInstallerFile);
                     $(ToolsetInstallerNuspecFile);
                     $(GenerateNupkgPowershellScript)"
@@ -176,9 +202,26 @@
                       '$(SdkMSICabFile)'" />
   </Target>
 
+  <Target Name="GenerateTemplatesNupkg"
+          DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs;GenerateTemplatesMsi;SignTemplatesMsi"
+          Condition=" '$(OS)' == 'Windows_NT' "
+          Inputs="$(TemplatesMSIInstallerFile);
+                    $(TemplatesInstallerNuspecFile);
+                    $(GenerateNupkgPowershellScript)"
+          Outputs="$(TemplatesInstallerNupkgFile)">
+
+    <Exec Command="powershell -NoProfile -NoLogo $(GenerateNupkgPowershellScript) ^
+                      '$(TemplatesMSIInstallerFile)' ^
+                      '$(FullNugetVersion)' ^
+                      '$(TemplatesInstallerNuspecFile)' ^
+                      '$(TemplatesInstallerNupkgFile)' ^
+                      '$(Architecture)' ^
+                      '$(TemplatesMSICabFile)'" />
+  </Target>
+
   <Target Name="GenerateVSToolsNupkg"
           DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs"
-          Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x86'"
+          Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x86' "
           Inputs="$(RedistLayoutPath)/**/*;
                   $(VSToolsNuspecFile);
                   $(GenerateNupkgPowershellScript)"
@@ -194,7 +237,7 @@
 
   <Target Name="GenerateVSToolsResolverNupkg"
           DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs"
-          Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x86'"
+          Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x86' "
           Inputs="$(SdkResolverLayoutPath)/**/*;
                   $(VSToolsResolverNuspecFile);
                   $(GenerateNupkgPowershellScript)"
@@ -235,13 +278,16 @@
                             AcquireWix;
                             GenerateSdkMsi;
                             SignSdkMsi;
+                            GenerateTemplatesMsi;
+                            SignTemplatesMsi;
                             GenerateSdkBundle;
                             SignSdkBundle;
                             GenerateToolsetNupkg;
+                            GenerateTemplatesNupkg;
                             GenerateVSToolsNupkg;
                             GenerateVSToolsResolverNupkg;
                             GenerateSdkMSBuildExtensionsNupkg"
-        Condition=" '$(OS)' == 'Windows_NT' and !$(Architecture.StartsWith('arm'))" />
+        Condition=" '$(OS)' == 'Windows_NT' and !$(Architecture.StartsWith('arm')) " />
 
 
 </Project>

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -131,7 +131,7 @@
             Condition=" '$(OSName)' == 'osx' ">
 
       <ItemGroup>
-        <TemplateFiles Include="$(RedistLayoutPath)Templates/**/*" />
+        <TemplateFiles Include="$(RedistLayoutPath)templates/**/*" />
       </ItemGroup>
       
       <!-- Copy ASP.NET runtime and targeting pack to internal layout, as we don't currently chain that in with a pkg dependency -->
@@ -141,7 +141,7 @@
                                  DestinationDirectory="$(SdkInternalLayoutPath)" />
 
       <Copy SourceFiles="@(TemplateFiles)"
-            DestinationFiles="@(TemplateFiles->'$(SdkInternalLayoutPath)/Templates/%(RecursiveDir)%(Filename)%(Extension)')" />
+            DestinationFiles="@(TemplateFiles->'$(SdkInternalLayoutPath)/templates/%(RecursiveDir)%(Filename)%(Extension)')" />
 
       <ReplaceFileContents
         InputFiles="$(SdkPkgScriptTemplateFile)"

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -129,12 +129,19 @@
             Outputs="$(SdkPKGInstallerFile)"
             DependsOnTargets="GenerateLayout;SetupPkgInputsOutputs"
             Condition=" '$(OSName)' == 'osx' ">
+
+      <ItemGroup>
+        <TemplateFiles Include="$(RedistLayoutPath)Templates/**/*" />
+      </ItemGroup>
       
       <!-- Copy ASP.NET runtime and targeting pack to internal layout, as we don't currently chain that in with a pkg dependency -->
       <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetCoreSharedFxArchiveFileName)"
                                  DestinationDirectory="$(SdkInternalLayoutPath)" />
       <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetTargetingPackArchiveFileName)"
                                  DestinationDirectory="$(SdkInternalLayoutPath)" />
+
+      <Copy SourceFiles="@(TemplateFiles)"
+            DestinationFiles="@(TemplateFiles->'$(SdkInternalLayoutPath)/Templates/%(RecursiveDir)%(Filename)%(Extension)')" />
 
       <ReplaceFileContents
         InputFiles="$(SdkPkgScriptTemplateFile)"

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -175,7 +175,7 @@
       <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
       <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
       <InputRoot>$(RedistLayoutPath)sdk/</InputRoot>
-      <DotnetNewTemplatesRoot>$(RedistLayoutPath)Templates/</DotnetNewTemplatesRoot>
+      <DotnetNewTemplatesRoot>$(RedistLayoutPath)templates/</DotnetNewTemplatesRoot>
       <SdkRPMInstallerFile>$(ArtifactsShippingPackagesDir)$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkRPMInstallerFile>
       <RpmFile>$(SdkRPMInstallerFile)</RpmFile>
       <!-- Need to acquire manpage files from CLI repo: https://github.com/dotnet/cli/issues/10266 -->
@@ -191,7 +191,7 @@
       <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
       <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
       <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
-      <RpmLayoutDotnetNewTemplates>$(RpmLayoutPackageRoot)/Templates</RpmLayoutDotnetNewTemplates>
+      <RpmLayoutDotnetNewTemplates>$(RpmLayoutPackageRoot)/templates</RpmLayoutDotnetNewTemplates>
       <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
       <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
       <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -39,6 +39,7 @@
     <!-- Copy files to rpm layout -->
     <ItemGroup>
       <SDKFiles Include="$(InputRoot)/**/*"/>
+      <DotnetNewTemplatesFiles Include="$(DotnetNewTemplatesRoot)**/*" />
       <SDKManpages Include="$(ManPagesDir)/**/*"/>
       <SDKTemplatesFiles Include="$(TemplatesDir)/**/*"/>
       <SDKScriptsFiles Include="$(ScriptsDir)/after_remove_host.sh"/>
@@ -46,6 +47,12 @@
 
     <Copy SourceFiles="@(SDKFiles)"
           DestinationFiles="@(SDKFiles->'$(RpmLayoutSDK)/%(RecursiveDir)%(Filename)%(Extension)')"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False"/>
+
+    <Copy SourceFiles="@(DotnetNewTemplatesFiles)"
+          DestinationFiles="@(DotnetNewTemplatesFiles->'$(RpmLayoutDotnetNewTemplates)/%(RecursiveDir)%(Filename)%(Extension)')"
           OverwriteReadOnlyFiles="True"
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False"/>
@@ -168,6 +175,7 @@
       <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
       <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
       <InputRoot>$(RedistLayoutPath)sdk/</InputRoot>
+      <DotnetNewTemplatesRoot>$(RedistLayoutPath)Templates/</DotnetNewTemplatesRoot>
       <SdkRPMInstallerFile>$(ArtifactsShippingPackagesDir)$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkRPMInstallerFile>
       <RpmFile>$(SdkRPMInstallerFile)</RpmFile>
       <!-- Need to acquire manpage files from CLI repo: https://github.com/dotnet/cli/issues/10266 -->
@@ -183,6 +191,7 @@
       <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
       <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
       <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
+      <RpmLayoutDotnetNewTemplates>$(RpmLayoutPackageRoot)/Templates</RpmLayoutDotnetNewTemplates>
       <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
       <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
       <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -42,9 +42,11 @@
       <HostMonikerRidForFileName Condition=" '$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true' ">$(Architecture)</HostMonikerRidForFileName>
 
       <ArtifactNameSdk>dotnet-sdk-internal</ArtifactNameSdk>
+      <ArtifactNameTemplates>dotnet-templates</ArtifactNameTemplates>
       <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 
       <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
+      <ArtifactNameWithVersionTemplates>$(ArtifactNameTemplates)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionTemplates>
       <ArtifactNameWithVersionMSBuildExtensions>dotnet-standard-support-vs2015-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionMSBuildExtensions>
       <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
       <!-- Warning: changing the value "ProductBandCombinedHostHostFxrFrameworkSdkName" can only occur on a product-band boundary [CliProductBandVersion], 

--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -147,7 +147,7 @@
 
     <ItemGroup>
       <SdkMsiFilesToSign Include="$(SdkMSIInstallerFile)" />
-      <SdkMsiFilesToSign Include="$(ArtifactsShippingPackagesDir)*.cab" />
+      <SdkMsiFilesToSign Include="$(ArtifactsShippingPackagesDir)d*.cab" />
 
       <SdkMsiFileSignInfo Include="@(SdkMsiFilesToSign->'%(Filename)%(Extension)')">
         <CertificateName>$(InternalCertificateId)</CertificateName>
@@ -162,6 +162,36 @@
         ItemsToSign="@(SdkMsiFilesToSign)"
         StrongNameSignInfo="@(StrongNameSignInfo)"
         FileSignInfo="@(DistinctSdkMsiFileSignInfo)"
+        FileExtensionSignInfo="@(FileExtensionSignInfo)"
+        TempDir="$(ArtifactsTmpDir)"
+        LogDir="$(ArtifactsLogDir)"
+        MSBuildPath="$(_DesktopMSBuildPath)"
+        SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
+        MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+
+  </Target>
+
+  <Target Name="SignTemplatesMsi"
+      Condition="'$(SignCoreSdk)' == 'true'"
+      DependsOnTargets="SetSignProps">
+
+    <ItemGroup>
+      <TemplatesMsiFilesToSign Include="$(TemplatesMSIInstallerFile)" />
+      <TemplatesMsiFilesToSign Include="$(ArtifactsShippingPackagesDir)t*.cab" />
+
+      <TemplatesMsiFileSignInfo Include="@(TemplatesMsiFilesToSign->'%(Filename)%(Extension)')">
+        <CertificateName>$(InternalCertificateId)</CertificateName>
+      </TemplatesMsiFileSignInfo>
+      <DistinctTemplatesMsiFileSignInfo Include="@(TemplatesMsiFileSignInfo->Distinct())" />
+    </ItemGroup>
+
+    <Microsoft.DotNet.SignTool.SignToolTask
+        DryRun="$(_DryRun)"
+        TestSign="$(_TestSign)"
+        CertificatesSignInfo="$(CertificatesSignInfo)"
+        ItemsToSign="@(TemplatesMsiFilesToSign)"
+        StrongNameSignInfo="@(StrongNameSignInfo)"
+        FileSignInfo="@(DistinctTemplatesMsiFileSignInfo)"
         FileExtensionSignInfo="@(FileExtensionSignInfo)"
         TempDir="$(ArtifactsTmpDir)"
         LogDir="$(ArtifactsLogDir)"

--- a/src/redist/targets/packaging/windows/clisdk/VS.Redist.Common.NetCore.Templates.nuspec
+++ b/src/redist/targets/packaging/windows/clisdk/VS.Redist.Common.NetCore.Templates.nuspec
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>VS.Redist.Common.NetCore.Templates.$ARCH$</id>
+        <version>1.0.0</version>
+        <title>VS.Redist.Common.NetCore.Templates.$ARCH$</title>
+        <authors>Microsoft</authors>
+        <owners>Microsoft</owners>
+        <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>
+        <projectUrl>https://github.com/dotnet/core-sdk</projectUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>.NET Core SDK Templates ($ARCH$) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</description>
+        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="$PAYLOAD_FILES$" />
+        <file src="$DOTNET_CAB_FILE$" />
+    </files>
+</package>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -142,6 +142,10 @@
       <MsiPackage SourceFile="$(var.WindowsDesktopTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
+      <MsiPackage SourceFile="$(var.TemplatesMsiSourcePath)">
+        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
+        <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
+      </MsiPackage>
       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
         <MsiProperty Name="DOTNETHOME_X86" Value="[DOTNETHOME_X86]" />

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -13,6 +13,7 @@ param(
     [Parameter(Mandatory=$true)][string]$NetStandardTargetingPackMSIFile,
     [Parameter(Mandatory=$true)][string]$AspNetTargetingPackMSIFile,
     [Parameter(Mandatory=$true)][string]$WindowsDesktopTargetingPackMSIFile,
+    [Parameter(Mandatory=$true)][string]$TemplatesMSIFile,
     [Parameter(Mandatory=$true)][string]$DotnetBundleOutput,
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$ProductMoniker,
@@ -53,6 +54,7 @@ function RunCandleForBundle
         -dNetStandardTargetingPackMsiSourcePath="$NetStandardTargetingPackMSIFile" `
         -dAspNetTargetingPackMsiSourcePath="$AspNetTargetingPackMSIFile" `
         -dWindowsDesktopTargetingPackMsiSourcePath="$WindowsDesktopTargetingPackMSIFile" `
+        -dTemplatesMsiSourcePath="$TemplatesMSIFile" `
         -dWinFormsAndWpfVersion="$WindowsDesktopVersion" `
         -dAdditionalSharedFXMsiSourcePath="$AdditionalSharedFxMSIFile" `
         -dAdditionalHostFXRMsiSourcePath="$AdditionalHostFxrMSIFile" `

--- a/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
@@ -1,0 +1,149 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$inputDir,
+    [Parameter(Mandatory=$true)][string]$DotnetMSIOutput,
+    [Parameter(Mandatory=$true)][string]$WixRoot,
+    [Parameter(Mandatory=$true)][string]$ProductMoniker,
+    [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
+    [Parameter(Mandatory=$true)][string]$SDKBundleVersion,
+    [Parameter(Mandatory=$true)][string]$DotnetCLINugetVersion,
+    [Parameter(Mandatory=$true)][string]$UpgradeCode,
+    [Parameter(Mandatory=$true)][string]$Architecture
+)
+
+$InstallFileswsx = ".\install-files.wxs"
+$InstallFilesWixobj = "install-files.wixobj"
+
+function RunHeat
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Information "Running heat.."
+
+    $heatOutput = .\heat.exe dir `"$inputDir`" -template fragment  `
+        -sreg -gg  `
+        -var var.DotnetSrc  `
+        -cg InstallFiles  `
+        -srd  `
+        -dr DOTNETHOME  `
+        -out install-files.wxs
+
+    Write-Information "Heat output: $heatOutput"
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Information "Heat failed with exit code $LastExitCode."
+    }
+
+    popd
+    Write-Information "RunHeat result: $result"
+    return $result
+}
+
+function RunCandle
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Information "Running candle.."
+
+    $candleOutput = .\candle.exe -nologo `
+        -dDotnetSrc="$inputDir" `
+        -dMicrosoftEula="$PSScriptRoot\clisdk\dummyeula.rtf" `
+        -dProductMoniker="$ProductMoniker" `
+        -dBuildVersion="$DotnetMSIVersion" `
+        -dSDKBundleVersion="$SDKBundleVersion" `
+        -dNugetVersion="$DotnetCLINugetVersion" `
+        -dUpgradeCode="$UpgradeCode" `
+        -arch "$Architecture" `
+        -ext WixDependencyExtension.dll `
+        "$PSScriptRoot\templates.wxs" `
+        "$PSScriptRoot\provider.wxs" `
+        $InstallFileswsx
+
+    Write-Information "Candle output: $candleOutput"
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Information "Candle failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunLight
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Information "Running light.."
+    $CabCache = Join-Path $WixRoot "cabcache"
+
+    $lightOutput = .\light.exe -nologo -ext WixUIExtension -ext WixDependencyExtension -ext WixUtilExtension `
+        -cultures:en-us `
+        templates.wixobj `
+        provider.wixobj `
+        $InstallFilesWixobj `
+        -b "$inputDir" `
+        -b "$PSScriptRoot" `
+        -reusecab `
+        -cc "$CabCache" `
+        -out $DotnetMSIOutput
+
+    Write-Information "Light output: $lightOutput"
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Information "Light failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+if(!(Test-Path $inputDir))
+{
+    throw "$inputDir not found"
+}
+
+Write-Information "Creating templates MSI at $DotnetMSIOutput"
+
+if([string]::IsNullOrEmpty($WixRoot))
+{
+    Exit -1
+}
+
+if(-Not (RunHeat))
+{
+    Write-Information "Heat failed"
+    Exit -1
+}
+
+if(-Not (RunCandle))
+{
+    Write-Information "Candle failed"
+    Exit -1
+}
+
+if(-Not (RunLight))
+{
+    Write-Information "Light failed"
+    Exit -1
+}
+
+if(!(Test-Path $DotnetMSIOutput))
+{
+    throw "Unable to create the templates MSI."
+    Exit -1
+}
+
+Write-Information "Successfully created templates MSI - $DotnetMSIOutput"
+
+exit $LastExitCode

--- a/src/redist/targets/packaging/windows/clisdk/templates.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/templates.wxs
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include "Variables.wxi" ?>
+  <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+
+    <Condition Message="$(var.ProductName) must be installed as part of a coordinated SDK installation.">
+      Installed OR ALLOWMSIINSTALL
+    </Condition>
+
+    <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
+    <?if $(var.Platform)=x86?>
+      <MediaTemplate CabinetTemplate="tx86-{0}.cab" CompressionLevel="high" />
+    <?elseif $(var.Platform)=x64?>
+      <MediaTemplate CabinetTemplate="tx64-{0}.cab" CompressionLevel="high" />
+    <?endif?>
+      
+    <Feature Id="MainFeature" Title="Main Feature" Level="1">
+      <ComponentGroupRef Id="InstallFiles" />
+    </Feature>
+    <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
+      <ComponentRef Id="$(var.DependencyKeyId)" />
+    </Feature>
+    <Property Id="ProductFamily" Value="$(var.ProductFamily)" />
+    <Property Id="ProductEdition" Value="$(var.ProductEdition)" />
+    <Property Id="ProductCPU" Value="$(var.Platform)" />
+    <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
+    <Property Id="MSIFASTINSTALL" Value="7" />
+    <Property Id="NUGETVERSION" Value="$(var.NugetVersion)" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
+
+    <Property Id="DOTNETEXE">
+      <DirectorySearch Id="DOTNETPATH" Path="[#DOTNETHOME]">
+        <FileSearch Id="DOTNETEXESEARCH" Name="dotnet.exe" />
+      </DirectorySearch>
+    </Property>
+
+    <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
+  </Product>
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="$(var.Program_Files)">
+        <Directory Id="DOTNETHOME" Name="dotnet"/>
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
Moves templates from inside the SDK to their own sub-hive under the dotnet hive.

This is part 1 of the work that will allows us to service templates separately from the Runtime.
Next step is to produce a 2.1 and 2.2 versions of the templates MSIs.