### PR TITLE
Removing the 'NuGetCommand' task

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -98,16 +98,6 @@ phases:
                   $(_AdditionalBuildParameters)
         displayName: Build
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.agentOs, 'Windows_NT')) }}:
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping/VS.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'), or(eq(variables['_BuildArchitecture'], 'x64'), eq(variables['_BuildArchitecture'], 'x86')))
-
     - task: PublishTestResults@1	
       displayName: Publish Test Results	
       inputs:


### PR DESCRIPTION
The 'NuGetCommand' task failed; removing it.

]The nuget command failed with exit code(1) and error(System.AggregateException: One or more errors occurred. ---> NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load the service index for source https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json. ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 401 (Unauthorized).

@jcagme 