### PR TITLE
[release/3.0.100-preview8] Updating the channel for latest

### DIFF
--- a/src/CopyToLatest/targets/BranchInfo.props
+++ b/src/CopyToLatest/targets/BranchInfo.props
@@ -1,5 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Channel>release/3.0.1xx</Channel>
+    <Channel>release/3.0.100-preview8</Channel>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This prevents this branch from competing and overwriting latest from release/3.0.1xx branch.