### PR TITLE
Run a set of tests from dotnet/sdk as integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,8 +95,10 @@ dlldata.c
 
 # Build artifacts
 artifacts/
+artifacts-*/
 bin/
 .dotnet/
+.dotnet-*/
 
 *_i.c
 *_p.c

--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkResolver", "src\SdkResol
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Dotnet.Sdk.Internal", "src\Microsoft.Dotnet.Sdk.Internal\Microsoft.Dotnet.Sdk.Internal.csproj", "{73F07908-981B-41BB-B9BD-F3420274A6F7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkTests", "test\SdkTests\SdkTests.csproj", "{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +65,7 @@ Global
 		{53AF2D01-B69F-4CD0-86A7-8FD95967D23C} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{78E15EC1-7732-41E3-8591-934E9F583254} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
+		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B526D2CE-EE2D-4AD4-93EF-1867D90FF1F5}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -26,6 +26,8 @@ phases:
     pool: ${{ parameters.pool }}
     ${{ if ne(parameters.strategy, '') }}:
       strategy: ${{ parameters.strategy }}
+    workspace:
+      clean: all
 
     variables: 
       - _AgentOSName: ${{ parameters.agentOs }}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -119,7 +119,7 @@ phases:
         testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
         platform: '$(BuildPlatform)'	
         configuration: '$(_BuildConfig)'	
-      condition: not(succeeded())
+      condition: ne(variables['TestParameter'], '')
 
     - task: CopyFiles@2	
       displayName: Gather Logs	

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -128,7 +128,7 @@ phases:
          TestResults/$(_BuildConfig)/**/*	
         TargetFolder: '$(Build.ArtifactStagingDirectory)'	
       continueOnError: true	
-      condition: not(succeeded())	
+      condition: always()
 
     - task: PublishBuildArtifacts@1	
       displayName: Publish Logs to VSTS	
@@ -137,4 +137,4 @@ phases:
         ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
         publishLocation: Container	
       continueOnError: true	
-      condition: not(succeeded())
+      condition: always()

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -128,7 +128,12 @@ function InitializeDotNetCli([bool]$install) {
   if ((-not $globalJsonHasRuntimes) -and ($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetSdkVersion"))) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
   } else {
+    
     $dotnetRoot = Join-Path $RepoRoot ".dotnet"
+    if ($env:ARCADE_PARTITION -ne $null)
+    {
+      $dotnetRoot = Join-Path $RepoRoot ".dotnet-$env:ARCADE_PARTITION"
+    }
 
     if (-not (Test-Path(Join-Path $dotnetRoot "sdk\$dotnetSdkVersion"))) {
       if ($install) {
@@ -561,6 +566,10 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $EngRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $ArtifactsDir = Join-Path $RepoRoot "artifacts"
+if ($env:ARCADE_PARTITION -ne $null)
+{
+  $ArtifactsDir = Join-Path $RepoRoot "artifacts-$env:ARCADE_PARTITION"
+}
 $ToolsetDir = Join-Path $ArtifactsDir "toolset"
 $ToolsDir = Join-Path $RepoRoot ".tools"
 $LogDir = Join-Path (Join-Path $ArtifactsDir "log") $configuration

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -131,7 +131,9 @@ function InitializeDotNetCli {
     dotnet_root="$DOTNET_INSTALL_DIR"
   else
     dotnet_root="$repo_root/.dotnet"
-
+    if [[ -n "${ARCADE_PARTITION:-}" ]]; then
+      dotnet_root="$repo_root/.dotnet-$ARCADE_PARTITION"
+    fi
     export DOTNET_INSTALL_DIR="$dotnet_root"
 
     if [[ ! -d "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version" ]]; then
@@ -360,6 +362,11 @@ _script_dir=`dirname "$_ResolvePath"`
 eng_root=`cd -P "$_script_dir/.." && pwd`
 repo_root=`cd -P "$_script_dir/../.." && pwd`
 artifacts_dir="$repo_root/artifacts"
+if [[ -n "${ARCADE_PARTITION:-}" ]]; then
+  artifacts_dir="$repo_root/artifacts-$ARCADE_PARTITION"
+  export ArtifactsDir="$artifacts_dir/"
+fi
+
 toolset_dir="$artifacts_dir/toolset"
 tools_dir="$repo_root/.tools"
 log_dir="$artifacts_dir/log/$configuration"

--- a/eng/core-sdk-build-env.sh
+++ b/eng/core-sdk-build-env.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+REPO_ROOT="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
+
+arcade_partition=
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
+  case "$opt" in
+    -partition)
+      arcade_partition=$2
+      shift
+      ;;
+  esac
+
+  shift
+done
+
+export ARCADE_PARTITION=$arcade_partition
+
+if [[ ! -z "$arcade_partition" ]]; then
+  arcade_partition_suffix="-$arcade_partition"
+fi
+
+export PATH=$REPO_ROOT/.dotnet$arcade_partition_suffix:$PATH
+export DOTNET_INSTALL_DIR=$REPO_ROOT/.dotnet$arcade_partition_suffix
+export ArtifactsDir=$REPO_ROOT/artifacts$arcade_partition_suffix/
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0

--- a/eng/dockerrun.ps1
+++ b/eng/dockerrun.ps1
@@ -55,7 +55,6 @@ docker run $interactiveFlag -t --rm --sig-proxy=true `
   -e PB_PACKAGEVERSIONPROPSURL `
   -e PB_PUBLISHBLOBFEEDURL `
   -e EXTERNALRESTORESOURCES `
-  -e ARCADE_DOTNET_DIR="/opt/code/artifacts/docker/${dockerImageName}/.dotnet" `
-  -e ARCADE_ARTIFACTS_DIR="/opt/code/artifacts/docker/${dockerImageName}/" `
+  -e ARCADE_PARTITION="${dockerImageName}" `
   $dockerContainerTag `
   /opt/code/run-build.sh @additionalArgs

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -113,6 +113,7 @@
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
+      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture "$(Architecture)"</InstallRuntimeCommand>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <InstallRuntimeCommand>/bin/bash</InstallRuntimeCommand>
@@ -120,6 +121,7 @@
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --install-dir "$(DotnetToTestPath)"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --runtime "dotnet"</InstallRuntimeCommand>
+      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) --architecture "$(Architecture)"</InstallRuntimeCommand>
     </PropertyGroup>
 
     <Exec Command="$(InstallRuntimeCommand)"

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -59,7 +59,7 @@
     </ItemGroup>
     <ItemGroup>
       <RuntimeVersionToInstall Include="2.1.0" />
-      <RuntimeVersionToInstall Include="2.2.4" />
+      <RuntimeVersionToInstall Include="2.2.5" />
     </ItemGroup>
     
   </Target>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -93,6 +93,12 @@
           DestinationFolder="$(TEMP)\dotnetSdkTests"
           SkipUnchangedFiles="true"
           />
+
+    <!-- Allow test list to be overridden with ToolTestName property -->
+    <ItemGroup Condition="'$(ToolTestName)' != ''">
+      <SdkTest Remove="@(SdkTest)" />
+      <SdkTest Include="$(ToolTestName)" />
+    </ItemGroup>
     
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="RunTestsAsTool"
@@ -115,7 +121,19 @@
     <Exec Command="dotnet new tool-manifest"
       WorkingDirectory="$(TestLocalToolFolder)"/>
 
-    <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(MicrosoftNETSdkPackageVersion) --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
+    <PropertyGroup>
+      <SdkTestPackageVersion>$(MicrosoftNETSdkPackageVersion)</SdkTestPackageVersion>
+      <SdkTestPackageFeed>https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</SdkTestPackageFeed>
+      
+      <InstallToolCommand>dotnet tool install --local $(ToolCommandName)</InstallToolCommand>
+      
+      <InstallToolCommand>$(InstallToolCommand) --version $(SdkTestPackageVersion)</InstallToolCommand>
+      <InstallToolCommand>$(InstallToolCommand) --add-source $(SdkTestPackageFeed)</InstallToolCommand>
+
+
+    </PropertyGroup>
+    
+    <Exec Command="$(InstallToolCommand)"
       WorkingDirectory="$(TestLocalToolFolder)"/>
 
     <Exec Command="dotnet tool restore"
@@ -133,10 +151,20 @@
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
     </PropertyGroup>
 
-    <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+      <ToolRunPrefix>$(ToolRunPrefix)set MSBuildSDKsPath= &amp;&amp; </ToolRunPrefix>
+      <ToolRunPrefix>$(ToolRunPrefix)set DOTNET_HOST_PATH= &amp;&amp; </ToolRunPrefix>
+      <ToolRunPrefix>$(ToolRunPrefix)set DOTNET_INSTALLDIR= &amp;&amp; </ToolRunPrefix>      
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+      <ToolRunPrefix>$(ToolRunPrefix)unset MSBuildSDKsPath &amp;&amp; </ToolRunPrefix>
+      <ToolRunPrefix>$(ToolRunPrefix)unset DOTNET_HOST_PATH &amp;&amp; </ToolRunPrefix>
+      <ToolRunPrefix>$(ToolRunPrefix)unset DOTNET_INSTALLDIR &amp;&amp; </ToolRunPrefix>
+    </PropertyGroup>
+
+    <Exec Command="$(ToolRunPrefix)dotnet tool run $(ToolCommandName) -- $(TestArgs)"
           WorkingDirectory="$(TestLocalToolFolder)"
-          IgnoreStandardErrorWarningFormat="true"
-          EnvironmentVariables="DOTNET_HOST_PATH=;DOTNET_INSTALLDIR="/>
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
   
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -25,6 +25,7 @@
 
   <PropertyGroup>
     <RedistLayoutPath>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</RedistLayoutPath>
+    <DotnetToTestPath>$(ArtifactsBinDir)redist\$(Configuration)\dotnet-with-previous-runtimes\</DotnetToTestPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,9 +36,53 @@
     <SdkTest Include="Rebuild" />
     <SdkTest Include="Restore" />
     <SdkTest Include="ToolPack" />
+
+    <RuntimeVersionToInstall Include="1.0.5" />
+    <RuntimeVersionToInstall Include="1.1.2" />
+    <RuntimeVersionToInstall Include="2.1.0" />
+    <RuntimeVersionToInstall Include="2.2.4" />
   </ItemGroup>
 
-  <Target Name="RunSdkTests">
+  <Target Name="SetupLayoutWithPreviousRuntimes">
+    <ItemGroup>
+      <LayoutFilesToCopyToDotnetToTest Include="$(RedistLayoutPath)**"/>
+      <LayoutFilesToCopyToDotnetToTest>
+        <DestinationPath>$(DotnetToTestPath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
+      </LayoutFilesToCopyToDotnetToTest>
+    </ItemGroup>
+    <Copy SourceFiles="@(LayoutFilesToCopyToDotnetToTest)"
+          DestinationFiles="@(LayoutFilesToCopyToDotnetToTest->'%(DestinationPath)')"
+          SkipUnchangedFiles="true"/>
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+         Targets="InstallRuntimeToLayout"
+         Properties="RuntimeVersionToInstall=%(RuntimeVersionToInstall.Identity)"
+         BuildInParallel="false"/>
+  </Target>
+
+  <Target Name="InstallRuntimeToLayout">
+    <PropertyGroup>
+      <RuntimeTargetDirectory>$(DotnetToTestPath)shared\Microsoft.NETCore.App\$(RuntimeVersionToInstall)</RuntimeTargetDirectory>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+      <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) $(_DotNetRoot)dotnet-install.ps1</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+      <InstallRuntimeCommand>$(_DotNetRoot)dotnet-install.sh</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) --version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) --install_dir $(DotnetToTestPath)</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) --runtime "dotnet"</InstallRuntimeCommand>
+    </PropertyGroup>
+
+    <Exec Command="$(InstallRuntimeCommand)"
+          Condition="!Exists($(RuntimeTargetDirectory))"/>
+  </Target>
+
+  <Target Name="RunSdkTests" DependsOnTargets="SetupLayoutWithPreviousRuntimes">
 
     <!-- SDK tests use the $(TEMP)\dotnetSdkTests as the working directory, isolate that from any higher-level
          Directory.Build files (TEMP is set to a folder in the repo when running in CI) -->
@@ -77,7 +122,7 @@
       <ResultsStdOutPath>$(ArtifactsLogDir)$(TestProjectName).log</ResultsStdOutPath>
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
-      <TestArgs>$(TestArgs) -dotnetPath $(RedistLayoutPath)\dotnet</TestArgs>
+      <TestArgs>$(TestArgs) -dotnetPath $(DotnetToTestPath)\dotnet</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -38,6 +38,14 @@
   </ItemGroup>
 
   <Target Name="RunSdkTests">
+
+    <!-- SDK tests use the $(TEMP)\dotnetSdkTests as the working directory, isolate that from any higher-level
+         Directory.Build files (TEMP is set to a folder in the repo when running in CI) -->
+    <Copy SourceFiles="$(RepoRoot)TestAssets\Directory.Build.props;$(RepoRoot)TestAssets\Directory.Build.targets"
+          DestinationFolder="$(TEMP)\dotnetSdkTests"
+          SkipUnchangedFiles="true"
+          />
+    
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="RunTestsAsTool"
              Properties="ToolCommandName=testSdk%(SdkTest.Identity);TestProjectName=Microsoft.NET.%(SdkTest.Identity).Tests"

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <RedistLayoutPath>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</RedistLayoutPath>
     <DotnetToTestPath>$(ArtifactsBinDir)redist\$(Configuration)\dotnet-with-previous-runtimes\</DotnetToTestPath>
+    <TestExecutionDirectory>$([MSBuild]::NormalizePath($(ArtifactsTmpDir), 'dotnetSdkTests'))</TestExecutionDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -109,9 +110,32 @@
 
     <!-- Isolate test working directory from higher-level Directory.Build files -->
     <Copy SourceFiles="$(RepoRoot)TestAssets\Directory.Build.props;$(RepoRoot)TestAssets\Directory.Build.targets"
-          DestinationFolder="$(ArtifactsTmpDir)/dotnetSdkTests"
+          DestinationFolder="$(TestExecutionDirectory)"
           SkipUnchangedFiles="true"
           />
+
+    <!-- Set up NuGet feeds -->
+    <PropertyGroup>
+      <GeneratedNuGetConfig>$(TestExecutionDirectory)\NuGet.config</GeneratedNuGetConfig>
+      <NugetConfigContents>
+        <![CDATA[
+<configuration>
+  <packageSources>
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
+    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
+    <add key="aspnet-entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
+    <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
+  </packageSources>
+</configuration>
+        ]]>
+      </NugetConfigContents>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(GeneratedNuGetConfig)"
+                  Lines="$(NugetConfigContents)"
+                  Overwrite="true" />
 
     <!-- Allow test list to be overridden with ToolTestName property -->
     <ItemGroup Condition="'$(ToolTestName)' != ''">
@@ -167,7 +191,8 @@
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
       <TestArgs>$(TestArgs) -dotnetPath $(DotnetToTestPath)\dotnet</TestArgs>
-      <TestArgs>$(TestArgs) -testExecutionDirectory $(ArtifactsTmpDir)/dotnetSdkTests</TestArgs>
+      <TestArgs>$(TestArgs) -testExecutionDirectory $(TestExecutionDirectory)</TestArgs>
+      <TestArgs>$(TestArgs) -testConfigFile "$(MSBuildThisFileDirectory)TestConfig.xml"</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -159,12 +159,16 @@
       <SdkTest Remove="@(SdkTest)" />
       <SdkTest Include="$(ToolTestName)" />
     </ItemGroup>
+
+    <ItemGroup>
+      <TestProjectToRun Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>ToolTestName=%(SdkTest.Identity)</AdditionalProperties>
+      </TestProjectToRun>
+    </ItemGroup>
     
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
+    <MSBuild Projects="@(TestProjectToRun)"
              Targets="RunTestsAsTool"
-             Properties="ToolTestName=%(SdkTest.Identity)"
              BuildInParallel="true"
-             ContinueOnError="true"
              />
   </Target>
   

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -103,7 +103,9 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="RunTestsAsTool"
              Properties="ToolTestName=%(SdkTest.Identity)"
-             BuildInParallel="true"/>
+             BuildInParallel="true"
+             ContinueOnError="true"
+             />
   </Target>
   
   <Target Name="RunTestsAsTool">

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -49,6 +49,11 @@
       <Output TaskParameter="Lines" PropertyName="OsReleaseContents"/>
     </ReadLinesFromFile>
 
+    <!-- Set OsReleaseContents to Windows to make later comparisons easier -->
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+      <OsReleaseContents>Windows</OsReleaseContents>
+    </PropertyGroup>
+
     <PropertyGroup Condition="$(OsReleaseContents.Contains('NAME=%22Ubuntu%22'))">
       <Supports1xRuntimes Condition="$(OsReleaseContents.Contains('VERSION_ID=%2218.04%22'))">false</Supports1xRuntimes>
     </PropertyGroup>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -80,7 +80,9 @@
     </PropertyGroup>
 
     <Exec Command="$(InstallRuntimeCommand)"
-          Condition="!Exists($(RuntimeTargetDirectory))"/>
+          Condition="!Exists($(RuntimeTargetDirectory))"
+          IgnoreStandardErrorWarningFormat="true"
+          />
   </Target>
 
   <Target Name="RunSdkTests" DependsOnTargets="SetupLayoutWithPreviousRuntimes">

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -36,14 +36,34 @@
     <SdkTest Include="Rebuild" />
     <SdkTest Include="Restore" />
     <SdkTest Include="ToolPack" />
-
-    <RuntimeVersionToInstall Include="1.0.5" />
-    <RuntimeVersionToInstall Include="1.1.2" />
-    <RuntimeVersionToInstall Include="2.1.0" />
-    <RuntimeVersionToInstall Include="2.2.4" />
   </ItemGroup>
 
-  <Target Name="SetupLayoutWithPreviousRuntimes">
+  <Target Name="GetRuntimesToInstall">
+    <PropertyGroup>
+      <Supports1xRuntimes>true</Supports1xRuntimes>
+    </PropertyGroup>
+
+    <ReadLinesFromFile File="/etc/os-release"
+                       Condition="'$(OS)' != 'Windows_NT'">
+      <Output TaskParameter="Lines" PropertyName="OsReleaseContents"/>
+    </ReadLinesFromFile>
+
+    <PropertyGroup Condition="$(OsReleaseContents.Contains('NAME=%22Ubuntu%22'))">
+      <Supports1xRuntimes Condition="$(OsReleaseContents.Contains('VERSION_ID=%2218.04%22'))">false</Supports1xRuntimes>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(Supports1xRuntimes)' == 'true'">
+      <RuntimeVersionToInstall Include="1.0.5" />
+      <RuntimeVersionToInstall Include="1.1.2" />      
+    </ItemGroup>
+    <ItemGroup>
+      <RuntimeVersionToInstall Include="2.1.0" />
+      <RuntimeVersionToInstall Include="2.2.4" />
+    </ItemGroup>
+    
+  </Target>
+
+  <Target Name="SetupLayoutWithPreviousRuntimes" DependsOnTargets="GetRuntimesToInstall">
     <ItemGroup>
       <LayoutFilesToCopyToDotnetToTest Include="$(RedistLayoutPath)**"/>
       <LayoutFilesToCopyToDotnetToTest>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -53,6 +53,23 @@
       <Supports1xRuntimes Condition="$(OsReleaseContents.Contains('VERSION_ID=%2218.04%22'))">false</Supports1xRuntimes>
     </PropertyGroup>
 
+    <PropertyGroup Condition="$(OsReleaseContents.Contains('NAME=Fedora'))">
+      <Supports1xRuntimes>false</Supports1xRuntimes>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(OsReleaseContents.Contains('NAME=%22openSUSE Leap%22'))">
+      <Supports1xRuntimes>false</Supports1xRuntimes>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(OsReleaseContents.Contains('NAME=%22Alpine Linux%22'))">
+      <Supports1xRuntimes>false</Supports1xRuntimes>
+    </PropertyGroup>
+
+    <!-- RHEL 6 does not appear to have the os-release file -->
+    <PropertyGroup Condition="'$(OsReleaseContents)' == ''">
+      <Supports1xRuntimes>false</Supports1xRuntimes>
+    </PropertyGroup>
+
     <ItemGroup Condition="'$(Supports1xRuntimes)' == 'true'">
       <RuntimeVersionToInstall Include="1.0.5" />
       <RuntimeVersionToInstall Include="1.1.2" />      

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -87,10 +87,9 @@
 
   <Target Name="RunSdkTests" DependsOnTargets="SetupLayoutWithPreviousRuntimes">
 
-    <!-- SDK tests use the $(TEMP)\dotnetSdkTests as the working directory, isolate that from any higher-level
-         Directory.Build files (TEMP is set to a folder in the repo when running in CI) -->
+    <!-- Isolate test working directory from higher-level Directory.Build files -->
     <Copy SourceFiles="$(RepoRoot)TestAssets\Directory.Build.props;$(RepoRoot)TestAssets\Directory.Build.targets"
-          DestinationFolder="$(TEMP)\dotnetSdkTests"
+          DestinationFolder="$(ArtifactsTmpDir)/dotnetSdkTests"
           SkipUnchangedFiles="true"
           />
 
@@ -148,6 +147,7 @@
 
       <TestArgs>-noautoreporters -noRepoInference</TestArgs>
       <TestArgs>$(TestArgs) -dotnetPath $(DotnetToTestPath)\dotnet</TestArgs>
+      <TestArgs>$(TestArgs) -testExecutionDirectory $(ArtifactsTmpDir)/dotnetSdkTests</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -93,12 +93,14 @@
     
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="RunTestsAsTool"
-             Properties="ToolCommandName=testSdk%(SdkTest.Identity);TestProjectName=Microsoft.NET.%(SdkTest.Identity).Tests"
+             Properties="ToolTestName=%(SdkTest.Identity)"
              BuildInParallel="true"/>
   </Target>
   
   <Target Name="RunTestsAsTool">
     <PropertyGroup>
+      <ToolCommandName>testSdk$(ToolTestName)</ToolCommandName>
+      <TestProjectName>Microsoft.NET.$(ToolTestName).Tests</TestProjectName>
       <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
     </PropertyGroup>
 

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -85,7 +85,8 @@
 
     <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
           WorkingDirectory="$(TestLocalToolFolder)"
-          IgnoreStandardErrorWarningFormat="true" />
+          IgnoreStandardErrorWarningFormat="true"
+          EnvironmentVariables="DOTNET_HOST_PATH=;DOTNET_INSTALLDIR="/>
   </Target>
   
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -212,7 +212,7 @@
       <TestArgs>$(TestArgs) -testConfigFile "$(MSBuildThisFileDirectory)TestConfig.xml"</TestArgs>
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
-      <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
+      <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath) 2&gt;&amp;1</TestArgs>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -227,8 +227,7 @@
     </PropertyGroup>
 
     <Exec Command="$(ToolRunPrefix)dotnet tool run $(ToolCommandName) -- $(TestArgs)"
-          WorkingDirectory="$(TestLocalToolFolder)"
-          IgnoreStandardErrorWarningFormat="true" />
+          WorkingDirectory="$(TestLocalToolFolder)" />
   </Target>
   
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -1,0 +1,115 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <OutputType>Library</OutputType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ResolvePackageDependenciesForBuild>false</ResolvePackageDependenciesForBuild>
+    <NonShipping>true</NonShipping>
+    <NoStdLib>true</NoStdLib>
+    <ProducesNoOutput>true</ProducesNoOutput>
+  </PropertyGroup>
+  
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
+
+    <IsPackable>false</IsPackable>
+
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+    <TargetFramework>$(CoreSdkTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RedistLayoutPath>$(ArtifactsBinDir)redist\$(Configuration)\dotnet\</RedistLayoutPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SdkTest Include="Build" />
+    <SdkTest Include="Clean" />
+    <SdkTest Include="Pack" />
+    <SdkTest Include="Publish" />
+    <SdkTest Include="Rebuild" />
+    <SdkTest Include="Restore" />
+    <SdkTest Include="ToolPack" />
+  </ItemGroup>
+
+  <Target Name="RunSdkTests">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="RunTestsAsTool"
+             Properties="ToolCommandName=testSdk%(SdkTest.Identity);TestProjectName=Microsoft.NET.%(SdkTest.Identity).Tests"
+             BuildInParallel="true"/>
+  </Target>
+  
+  <Target Name="RunTestsAsTool">
+    <PropertyGroup>
+      <TestLocalToolFolder>$(ArtifactsTmpDir)$(ToolCommandName)\</TestLocalToolFolder>
+    </PropertyGroup>
+
+    <RemoveDir Directories="$(TestLocalToolFolder)" />
+    <MakeDir Directories="$(TestLocalToolFolder)" />
+
+    <MakeDir Directories="$(ArtifactsTestResultsDir)" />
+
+    <Exec Command="dotnet new tool-manifest"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
+
+    <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(MicrosoftNETSdkPackageVersion) --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
+
+    <Exec Command="dotnet tool restore"
+      WorkingDirectory="$(TestLocalToolFolder)"/>
+
+    <PropertyGroup>
+      <ResultsXmlPath>$(ArtifactsTestResultsDir)$(TestProjectName).xml</ResultsXmlPath>
+      <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(TestProjectName).html</ResultsHtmlPath>
+      <ResultsStdOutPath>$(ArtifactsLogDir)$(TestProjectName).log</ResultsStdOutPath>
+
+      <TestArgs>-noautoreporters -noRepoInference</TestArgs>
+      <TestArgs>$(TestArgs) -dotnetPath $(RedistLayoutPath)\dotnet</TestArgs>
+      <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
+      <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
+      <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
+    </PropertyGroup>
+
+    <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
+          WorkingDirectory="$(TestLocalToolFolder)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+  
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- Remove items which light up build logic which could generate warnings / errors -->
+  <ItemGroup>
+    <EmbeddedResource Remove="@(EmbeddedResource)" />
+    <Reference Remove="@(Reference)" />
+    <PackageReference Remove="@(PackageReference)" />
+    <ProjectReference Remove="@(ProjectReference)" />
+    <SwrFile Remove="@(SwrFile)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetPath></TargetPath>
+    <!-- Prevent projects referencing this from trying to pass us to the compiler -->
+  </PropertyGroup>
+
+  <Target Name="CoreCompile" />
+  <!-- Prevent Csc from being called -->
+  <Target Name="GenerateTargetFrameworkMonikerAttribute" />
+  <!-- Don't generate TFM attribute -->
+  <Target Name="RuntimeImplementationProjectOutputGroup" />
+  <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
+  <Target Name="GetReferenceAssemblyPaths" />
+  <!-- Don't go looking for framewoek reference assemblies-->
+  <Target Name="GetFrameworkPaths"  />
+  <!-- ^ -->
+
+  <Target Name="GetBuildVersion" />
+  <!-- For Packages projects, which use GetNuGetPackageVersionEx which depends on GetBuildVersion -->
+  <Target Name="Pack" />
+
+  <Target Name="Test" DependsOnTargets="RunSdkTests" />
+</Project>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -66,15 +66,16 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
       <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) $(_DotNetRoot)dotnet-install.ps1</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-      <InstallRuntimeCommand>$(_DotNetRoot)dotnet-install.sh</InstallRuntimeCommand>
+      <InstallRuntimeCommand>/bin/bash</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.sh"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) --install_dir $(DotnetToTestPath)</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) --install-dir "$(DotnetToTestPath)"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --runtime "dotnet"</InstallRuntimeCommand>
     </PropertyGroup>
 

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -224,6 +224,7 @@
       <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
       <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
       <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath) 2&gt;&amp;1</TestArgs>
+      <TestArgs>$(TestArgs) -testList SdkIntegrationTests</TestArgs>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -227,6 +227,12 @@
       <TestArgs>$(TestArgs) -testList SdkIntegrationTests</TestArgs>
     </PropertyGroup>
 
+
+    <PropertyGroup Condition="('$(OS)' == 'Windows_NT') And ('$(Architecture)' == 'x86')">
+      <!-- Add list of tests to skip on x86 -->
+      <TestArgs>$(TestArgs) -testConfigFile "$(MSBuildThisFileDirectory)TestsToSkipx86.xml"</TestArgs>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
       <ToolRunPrefix>$(ToolRunPrefix)set MSBuildSDKsPath= &amp;&amp; </ToolRunPrefix>
       <ToolRunPrefix>$(ToolRunPrefix)set DOTNET_HOST_PATH= &amp;&amp; </ToolRunPrefix>

--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -1,0 +1,78 @@
+<Tests>
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.RuntimeFrameworkVersionCanBeSpecifiedOnFrameworkReference"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3221"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TargetingPackVersionCanBeSpecifiedOnFrameworkReference"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3221"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TargetLatestPatchCanBeSpecifiedOnFrameworkReference"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3221"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TransitiveFrameworkReferenceFromPackageReference"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3221"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TransitiveFrameworkReferenceFromProjectReference"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3221"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToResolveConflicts.AProjectCanReferenceADllInAPackageDirectly"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3214"
+            Reason="Code flow needed"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_targets_the_right_framework_depending_on_output_type"
+            Skip="true"
+            Issue=""
+            Reason="Test needs to be updated with new patches (along with SDK stage 0 update)"/>
+
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithLibrariesAndRid.It_builds_a_RID_specific_runnable_output"
+            Skip="true"
+            Issue=""
+            Reason="Test doesn't work with newer RIDs"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithLibrariesAndRid.It_builds_a_framework_dependent_RID_specific_runnable_output"
+            Skip="true"
+            Issue=""
+            Reason="Test doesn't work with newer RIDs"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_handles_mismatched_implicit_package_versions"
+            Skip="true"
+            Issue=""
+            Reason="Test doesn't work with newer RIDs"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithLibrary.It_builds_the_project_successfully"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithLibrary.It_builds_the_project_successfully_twice"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThereAreDefaultItems.Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+
+</Tests>

--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -29,6 +29,11 @@
             Issue="https://github.com/dotnet/sdk/pull/3214"
             Reason="Code flow needed"/>
 
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPreserveCompilationContext.It_publishes_the_project_with_a_refs_folder_and_correct_deps_file"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3237"
+            Reason="Code flow needed"/>
+
     <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_targets_the_right_framework_depending_on_output_type"
             Skip="true"
             Issue=""

--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -55,7 +55,7 @@
             Issue=""
             Reason="Test doesn't work with newer RIDs"/>
 
-    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs"
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.It_builds_the_project_successfully"
             Skip="true"
             Issue=""
             Reason="Needs .NET Core 1.1"/>
@@ -70,14 +70,24 @@
             Issue=""
             Reason="Needs .NET Core 1.1"/>
 
-    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources"
-            Skip="true"
-            Issue=""
-            Reason="Needs .NET Core 1.1"/>
+  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources"
+          Skip="true"
+          Issue=""
+          Reason="Needs .NET Core 1.1"/>
 
-    <Method Name="Microsoft.NET.Build.Tests.GivenThereAreDefaultItems.Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used"
-            Skip="true"
-            Issue=""
-            Reason="Needs .NET Core 1.1"/>
+  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.It_retrieves_strings_successfully"
+          Skip="true"
+          Issue=""
+          Reason="Needs .NET Core 1.1"/>
+
+  <Method Name="Microsoft.NET.Build.Tests.GivenThereAreDefaultItems.Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used"
+          Skip="true"
+          Issue=""
+          Reason="Needs .NET Core 1.1"/>
+
+  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildASelfContainedApp.It_succeeds_when_RuntimeIdentifier_and_PlatformTarget_mismatch_but_PT_is_AnyCPU"
+          Skip="true"
+          Issue=""
+          Reason="Needs .NET Core 1.1"/>
 
 </Tests>

--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -45,6 +45,11 @@
   </TestList>
   
   <SkippedTests>
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAHelloWorldProject.It_publishes_portable_apps_to_the_publish_folder_and_the_app_should_run"
+            Skip="true"
+            Issue="https://github.com/dotnet/sdk/pull/3574"
+            Reason="Test update needed (in PR)"/>
+
     <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.RuntimeFrameworkVersionCanBeSpecifiedOnFrameworkReference"
             Skip="true"
             Issue="https://github.com/dotnet/sdk/pull/3221"

--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -1,4 +1,50 @@
 <Tests>
+  <TestList Name="SdkIntegrationTests">
+    <!-- Build tests -->
+    <Method Name="Microsoft.NET.Build.Tests.AppHostTests.It_builds_a_runnable_apphost_by_default" />
+    <Class Name="Microsoft.NET.Build.Tests.DesignTimeBuildTests" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TransitiveFrameworkReferenceFromPackageReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.TransitiveFrameworkReferenceFromProjectReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.WPFFrameworkReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.WindowsDesktopFrameworkReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.WindowsFormAndWPFFrameworkReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.WindowsFormsFrameworkReference" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantBuildsToBeIncremental.ResolvePackageAssets_runs_incrementally" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildADesktopExe.It_builds_a_simple_desktop_app" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildADesktopExeWithFSharp" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildALibrary.It_builds_the_library_successfully" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildALibraryWithFSharp.It_builds_the_library_successfully" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildALibraryWithVB.It_builds_the_library_successfully" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.BuildWithTransitiveReferenceToNetCoreAppPackage" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_a_rid_specific_app_from_the_output_folder" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_a_rid_specific_app_with_conflicts_from_the_output_folder" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_the_app_from_the_output_folder" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_the_app_with_conflicts_from_the_output_folder" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetStandard2Library" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildASelfContainedApp.It_builds_a_runnable_output" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAUnitTestProject" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithLibrariesAndRid" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildAnAppWithTransitiveProjectRefs.It_builds_the_project_successfully" />
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToResolveConflicts.FilesFromAspNetCoreSharedFrameworkAreNotIncluded" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenThatWeWantToUseVB" />
+    <Class Name="Microsoft.NET.Build.Tests.GivenWeWantToRequireWindowsForDesktopApps" />
+    
+    <!-- Publish tests -->
+    <Class Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAFrameworkDependentApp" />
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAHelloWorldProject.It_publishes_portable_apps_to_the_publish_folder_and_the_app_should_run" />
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAHelloWorldProject.It_publishes_self_contained_apps_to_the_publish_folder_and_the_app_should_run" />
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAHelloWorldProject.It_publishes_with_a_publish_profile" />
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishASelfContainedApp.It_can_make_a_Windows_GUI_exe" />
+    <Class Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishASingleFileApp" />
+    <Class Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAWebApp" />
+    <Class Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToRunCrossgen" />
+    <Class Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToRunILLink" />
+    <Class Name="Microsoft.NET.Publish.Tests.PublishWebApp" />
+    <Class Name="Microsoft.NET.Publish.Tests.PublishWpfApp" />
+    
+  </TestList>
+  
+  <SkippedTests>
     <Method Name="Microsoft.NET.Build.Tests.GivenFrameworkReferences.RuntimeFrameworkVersionCanBeSpecifiedOnFrameworkReference"
             Skip="true"
             Issue="https://github.com/dotnet/sdk/pull/3221"
@@ -70,24 +116,25 @@
             Issue=""
             Reason="Needs .NET Core 1.1"/>
 
-  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources"
-          Skip="true"
-          Issue=""
-          Reason="Needs .NET Core 1.1"/>
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.TestSatelliteResources"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
 
-  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.It_retrieves_strings_successfully"
-          Skip="true"
-          Issue=""
-          Reason="Needs .NET Core 1.1"/>
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantAllResourcesInSatellite.It_retrieves_strings_successfully"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
 
-  <Method Name="Microsoft.NET.Build.Tests.GivenThereAreDefaultItems.Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used"
-          Skip="true"
-          Issue=""
-          Reason="Needs .NET Core 1.1"/>
+    <Method Name="Microsoft.NET.Build.Tests.GivenThereAreDefaultItems.Compile_items_can_be_explicitly_specified_while_default_EmbeddedResource_items_are_used"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
 
-  <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildASelfContainedApp.It_succeeds_when_RuntimeIdentifier_and_PlatformTarget_mismatch_but_PT_is_AnyCPU"
-          Skip="true"
-          Issue=""
-          Reason="Needs .NET Core 1.1"/>
-
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildASelfContainedApp.It_succeeds_when_RuntimeIdentifier_and_PlatformTarget_mismatch_but_PT_is_AnyCPU"
+            Skip="true"
+            Issue=""
+            Reason="Needs .NET Core 1.1"/>
+    
+  </SkippedTests>
 </Tests>

--- a/test/SdkTests/TestsToSkipx86.xml
+++ b/test/SdkTests/TestsToSkipx86.xml
@@ -1,0 +1,20 @@
+<Tests>
+  <SkippedTests>
+    <Method Name="Microsoft.NET.Publish.Tests.GivenThatWeWantToPublishAFrameworkDependentApp.It_publishes_with_or_without_apphost"
+            Skip="true"
+            Reason="Test assumes test process architecture is the same as architecture under test"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_a_rid_specific_app_with_conflicts_from_the_output_folder"
+          Skip="true"
+          Reason="Test assumes test process architecture is the same as architecture under test"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.GivenThatWeWantToBuildANetCoreApp.It_runs_a_rid_specific_app_from_the_output_folder"
+          Skip="true"
+          Reason="Test assumes test process architecture is the same as architecture under test"/>
+
+    <Method Name="Microsoft.NET.Build.Tests.AppHostTests.It_builds_a_runnable_apphost_by_default"
+          Skip="true"
+          Reason="Test assumes test process architecture is the same as architecture under test"/>
+
+  </SkippedTests>
+</Tests>


### PR DESCRIPTION
Re-use test assets from the dotnet/sdk repo as integration tests for core-sdk.

This replaces #1454.  In that PR I was trying to run all of the SDK tests in core-sdk, and fixing or disabling the failing tests.  Now with this PR we'll just have a list of integration tests to run.  Running all the SDK tests would have taken too long anyway.  If we do want to run all of them we will need to figure out a way to do so without blocking PRs on them.