### PR TITLE
Change docker container setup so azure devops artifact upload works

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ done
 
 dockerbuild()
 {
-    BUILD_COMMAND=/opt/code/run-build.sh $DIR/eng/dockerrun.sh --non-interactive "$@"
+    BUILD_COMMAND=$DIR/run-build.sh $DIR/eng/dockerrun.sh --non-interactive "$@"
 }
 
 # Check if we need to build in docker

--- a/eng/docker/alpine.3.6/Dockerfile
+++ b/eng/docker/alpine.3.6/Dockerfile
@@ -21,6 +21,7 @@ RUN chmod -R a+rwx /home
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 

--- a/eng/docker/centos/Dockerfile
+++ b/eng/docker/centos/Dockerfile
@@ -21,5 +21,6 @@ RUN chmod -R 755 /usr/bin/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/debian/Dockerfile
+++ b/eng/docker/debian/Dockerfile
@@ -27,5 +27,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/fedora.23/Dockerfile
+++ b/eng/docker/fedora.23/Dockerfile
@@ -26,5 +26,6 @@ RUN chmod -R a+rwx /home
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/fedora.24/Dockerfile
+++ b/eng/docker/fedora.24/Dockerfile
@@ -25,4 +25,5 @@ RUN chmod -R a+rwx /home
 USER ${USER_ID} 
  
 # Set working directory 
-WORKDIR /opt/code
+ARG WORK_DIR 
+WORKDIR ${WORK_DIR}

--- a/eng/docker/fedora.27/Dockerfile
+++ b/eng/docker/fedora.27/Dockerfile
@@ -29,4 +29,5 @@ RUN chmod -R a+rwx /home
 USER ${USER_ID} 
  
 # Set working directory 
-WORKDIR /opt/code
+ARG WORK_DIR 
+WORKDIR ${WORK_DIR}

--- a/eng/docker/fedora.28/Dockerfile
+++ b/eng/docker/fedora.28/Dockerfile
@@ -26,4 +26,5 @@ RUN chmod -R a+rwx /home
 USER ${USER_ID} 
  
 # Set working directory 
-WORKDIR /opt/code
+ARG WORK_DIR 
+WORKDIR ${WORK_DIR}

--- a/eng/docker/fedora.29/Dockerfile
+++ b/eng/docker/fedora.29/Dockerfile
@@ -26,4 +26,5 @@ RUN chmod -R a+rwx /home
 USER ${USER_ID} 
  
 # Set working directory 
-WORKDIR /opt/code
+ARG WORK_DIR 
+WORKDIR ${WORK_DIR}

--- a/eng/docker/opensuse.13.2/Dockerfile
+++ b/eng/docker/opensuse.13.2/Dockerfile
@@ -21,5 +21,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/opensuse.42.1/Dockerfile
+++ b/eng/docker/opensuse.42.1/Dockerfile
@@ -46,5 +46,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/opensuse.42.3/Dockerfile
+++ b/eng/docker/opensuse.42.3/Dockerfile
@@ -45,5 +45,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/rhel.6/Dockerfile
+++ b/eng/docker/rhel.6/Dockerfile
@@ -26,6 +26,7 @@ USER ${USER_ID}
 # Set library path to make CURL and ICU libraries that are in /usr/local/lib visible
 ENV LD_LIBRARY_PATH /usr/local/lib
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 

--- a/eng/docker/rhel/Dockerfile
+++ b/eng/docker/rhel/Dockerfile
@@ -19,5 +19,6 @@ RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/ubuntu.14.04/Dockerfile
+++ b/eng/docker/ubuntu.14.04/Dockerfile
@@ -59,5 +59,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/ubuntu.16.04/Dockerfile
+++ b/eng/docker/ubuntu.16.04/Dockerfile
@@ -52,5 +52,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/ubuntu.16.10/Dockerfile
+++ b/eng/docker/ubuntu.16.10/Dockerfile
@@ -59,5 +59,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/docker/ubuntu.18.04/Dockerfile
+++ b/eng/docker/ubuntu.18.04/Dockerfile
@@ -27,5 +27,6 @@ RUN chmod -R 755 /usr/lib/sudo
 # Set user to the one we just created
 USER ${USER_ID}
 
-# Set working directory
-WORKDIR /opt/code
+# Set working directory 
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}

--- a/eng/dockerrun.ps1
+++ b/eng/dockerrun.ps1
@@ -19,7 +19,7 @@ Write-Host "Additional args: $additionalArgs"
 
 $dockerFile = Resolve-Path (Join-Path $RepoRoot "eng\docker\$dockerImageName")
 
-docker build --build-arg USER_ID=1000 -t "$dockerContainerTag" $dockerFile
+docker build --build-arg WORK_DIR=$RepoRoot --build-arg USER_ID=1000 -t "$dockerContainerTag" $dockerFile
 
 $interactiveFlag = "-i"
 if ($noninteractive)
@@ -31,7 +31,7 @@ if ($noninteractive)
 
 docker run $interactiveFlag -t --rm --sig-proxy=true `
   --name "$dockerContainerName" `
-  -v "${RepoRoot}:/opt/code" `
+  -v "${RepoRoot}:${RepoRoot}" `
   -e DOTNET_CORESDK_IGNORE_TAR_EXIT_CODE=1 `
   -e CHANNEL `
   -e DOTNET_BUILD_SKIP_CROSSGEN `
@@ -55,7 +55,7 @@ docker run $interactiveFlag -t --rm --sig-proxy=true `
   -e PB_PACKAGEVERSIONPROPSURL `
   -e PB_PUBLISHBLOBFEEDURL `
   -e EXTERNALRESTORESOURCES `
-  -e ARCADE_DOTNET_DIR="/opt/code/artifacts/docker/${dockerImageName}/.dotnet" `
-  -e ARCADE_ARTIFACTS_DIR="/opt/code/artifacts/docker/${dockerImageName}/" `
+  -e ARCADE_DOTNET_DIR="${RepoRoot}/artifacts/docker/${dockerImageName}/.dotnet" `
+  -e ARCADE_ARTIFACTS_DIR="${RepoRoot}/artifacts/docker/${dockerImageName}/" `
   $dockerContainerTag `
-  /opt/code/run-build.sh @additionalArgs
+  ${RepoRoot}/run-build.sh @additionalArgs

--- a/eng/dockerrun.sh
+++ b/eng/dockerrun.sh
@@ -39,7 +39,7 @@ while [[ $# > 0 ]]; do
             echo "Options:"
             echo "  <Dockerfile>    The path to the Dockerfile to use to create the build container"
             echo "  <ImageName>     The name of an existing Dockerfile folder under eng/docker to use as the Dockerfile"
-            echo "  <Command>  The command to run once inside the container (/opt/code is mapped to the repo root; defaults to nothing, which runs the default shell)"
+            echo "  <Command>  The command to run once inside the container (DOCKER_HOST_SHARE_DIR is mapped to repo root; defaults to nothing, which runs the default shell)"
             exit 0
             ;;
         *)
@@ -107,7 +107,7 @@ fi
 
 # Build the docker container (will be fast if it is already built)
 echo "Building Docker Container using Dockerfile: $DOCKERFILE"
-docker build --build-arg USER_ID=$(id -u) -t $DOTNET_BUILD_CONTAINER_TAG $DOCKERFILE
+docker build --build-arg WORK_DIR=$DOCKER_HOST_SHARE_DIR --build-arg USER_ID=$(id -u) -t $DOTNET_BUILD_CONTAINER_TAG $DOCKERFILE
 
 # Run the build in the container
 echo "Launching build in Docker Container"
@@ -118,7 +118,7 @@ echo "Using code from: $DOCKER_HOST_SHARE_DIR"
 # Note: passwords/keys should not be passed in the environment
 docker run $INTERACTIVE -t --rm --sig-proxy=true \
     --name $DOTNET_BUILD_CONTAINER_NAME \
-    -v $DOCKER_HOST_SHARE_DIR:/opt/code \
+    -v $DOCKER_HOST_SHARE_DIR:$DOCKER_HOST_SHARE_DIR \
     -e CHANNEL \
     -e DOTNET_BUILD_SKIP_CROSSGEN \
     -e PUBLISH_TO_AZURE_BLOB \


### PR DESCRIPTION
See the comment at https://github.com/dotnet/core-eng/issues/7657#issuecomment-526282980

Changing the working directory mapping within the container so that the paths match makes it so the azure pipelines agents are able to find and upload the files.

See https://dev.azure.com/dnceng/internal/_build/results?buildId=330590&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=082dac6f-41ac-58bd-afc2-ad5f15455c1a for a build with these changes that is successfully able to upload build artifacts.