### PR TITLE
[release/3.0.1xx] Fix resource branding

### DIFF
--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -159,13 +159,13 @@
         <ReplacementString>$(SdkBrandName)</ReplacementString>
       </DebianConfigTokenValues>
       <DebianConfigTokenValues Include="%SHARED_FRAMEWORK_DEBIAN_PACKAGE_VERSION%">
-        <ReplacementString>$(MicrosoftNETCoreAppPackageVersionWithTilda)</ReplacementString>
+        <ReplacementString>$(MicrosoftNETCoreAppPackageVersionWithTilde)</ReplacementString>
       </DebianConfigTokenValues>
       <DebianConfigTokenValues Include="%NET_STANDARD_DEBIAN_PACKAGE_VERSION%">
-        <ReplacementString>$(NetStandardTargetingPackPackageVersionWithTilda)</ReplacementString>
+        <ReplacementString>$(NetStandardTargetingPackPackageVersionWithTilde)</ReplacementString>
       </DebianConfigTokenValues>
       <DebianConfigTokenValues Include="%ASPNETCORE_SHAREDFX_DEBIAN_PACKAGE_VERSION%">
-        <ReplacementString>$(AspNetCoreVersionWithTilda)</ReplacementString>
+        <ReplacementString>$(AspNetCoreVersionWithTilde)</ReplacementString>
       </DebianConfigTokenValues>
 
       <DebianPostInstTokenValues Include="%SDK_VERSION%">

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -249,11 +249,11 @@
                       '$(MsiVersion)' ^
                       '$(SDKBundleVersion)' ^
                       '$(NugetVersion)' ^
-                      '$(MicrosoftWindowsDesktopPackageVersion)' ^
+                      '$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)' ^
                       '$(CombinedFrameworkSDKHostInstallerUpgradeCode)' ^
                       '$(SdkDependencyKeyName)' ^
                       '$(Architecture)' ^
-                      '$(MicrosoftNETCoreAppPackageVersion)' ^
+                      '$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)' ^
                       '$(AspNetCoreVersion)' ^
                       '$(CliProductBandVersion)' ^
                       -InformationAction Continue " />

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -94,7 +94,7 @@
           <ReplacementString>$(SdkVersion)</ReplacementString>
         </ResourcesReplacement>
         <ResourcesReplacement Include="{DOTNETRUNTIMEVERSION}">
-          <ReplacementString>$(MicrosoftNETCoreAppPackageVersion)</ReplacementString>
+          <ReplacementString>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</ReplacementString>
         </ResourcesReplacement>
         <ResourcesReplacement Include="{ASPNETCOREVERSION}">
           <ReplacementString>$(AspNetCoreVersion)</ReplacementString>

--- a/src/redist/targets/LinuxNativeInstallerDependencyVersions.targets
+++ b/src/redist/targets/LinuxNativeInstallerDependencyVersions.targets
@@ -2,25 +2,25 @@
 <Project>
   <Target Name="CalculateLinuxNativeInstallerDependencyVersions">
     <PropertyGroup>
-      <MicrosoftNETCoreAppPatchSeparatorIndex>$([MSBuild]::Add($(MicrosoftNETCoreAppPackageVersion.IndexOf('.')), 1))</MicrosoftNETCoreAppPatchSeparatorIndex>
-      <MicrosoftNETCoreAppPatchSeparatorIndex>$(MicrosoftNETCoreAppPackageVersion.IndexOf('.', $(MicrosoftNETCoreAppPatchSeparatorIndex)))</MicrosoftNETCoreAppPatchSeparatorIndex>
-      <MicrosoftNETCoreAppMajorMinorVersion>$(MicrosoftNETCoreAppPackageVersion.Substring(0, $(MicrosoftNETCoreAppPatchSeparatorIndex)))</MicrosoftNETCoreAppMajorMinorVersion>
+      <MicrosoftNETCoreAppPatchSeparatorIndex>$([MSBuild]::Add($(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.IndexOf('.')), 1))</MicrosoftNETCoreAppPatchSeparatorIndex>
+      <MicrosoftNETCoreAppPatchSeparatorIndex>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.IndexOf('.', $(MicrosoftNETCoreAppPatchSeparatorIndex)))</MicrosoftNETCoreAppPatchSeparatorIndex>
+      <MicrosoftNETCoreAppMajorMinorVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.Substring(0, $(MicrosoftNETCoreAppPatchSeparatorIndex)))</MicrosoftNETCoreAppMajorMinorVersion>
 
-      <MicrosoftNETCoreAppVersionPreReleaseSeparator>$(MicrosoftNETCoreAppPackageVersion.IndexOf('-'))</MicrosoftNETCoreAppVersionPreReleaseSeparator>
-      <MicrosoftNETCoreAppMajorMinorPatchVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppMajorMinorPatchVersion>
-      <MicrosoftNETCoreAppMajorMinorPatchVersion Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppPackageVersion.Substring(0, $(MicrosoftNETCoreAppVersionPreReleaseSeparator)))</MicrosoftNETCoreAppMajorMinorPatchVersion>
+      <MicrosoftNETCoreAppVersionPreReleaseSeparator>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.IndexOf('-'))</MicrosoftNETCoreAppVersionPreReleaseSeparator>
+      <MicrosoftNETCoreAppMajorMinorPatchVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppMajorMinorPatchVersion>
+      <MicrosoftNETCoreAppMajorMinorPatchVersion Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.Substring(0, $(MicrosoftNETCoreAppVersionPreReleaseSeparator)))</MicrosoftNETCoreAppMajorMinorPatchVersion>
       <MicrosoftNETCoreAppVersionPreReleaseSeparatorStartIndex>$([MSBuild]::Add($(MicrosoftNETCoreAppVersionPreReleaseSeparator), 1))</MicrosoftNETCoreAppVersionPreReleaseSeparatorStartIndex>
-      <MicrosoftNETCoreVersionSuffix Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppPackageVersion.Substring($(MicrosoftNETCoreAppVersionPreReleaseSeparatorStartIndex)))</MicrosoftNETCoreVersionSuffix>
-      <MicrosoftNETCoreAppPackageVersionWithTilda>$(MicrosoftNETCoreAppMajorMinorPatchVersion)</MicrosoftNETCoreAppPackageVersionWithTilda>
-      <MicrosoftNETCoreAppPackageVersionWithTilda Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppMajorMinorPatchVersion)~$(MicrosoftNETCoreVersionSuffix)</MicrosoftNETCoreAppPackageVersionWithTilda>
+      <MicrosoftNETCoreVersionSuffix Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion.Substring($(MicrosoftNETCoreAppVersionPreReleaseSeparatorStartIndex)))</MicrosoftNETCoreVersionSuffix>
+      <MicrosoftNETCoreAppPackageVersionWithTilde>$(MicrosoftNETCoreAppMajorMinorPatchVersion)</MicrosoftNETCoreAppPackageVersionWithTilde>
+      <MicrosoftNETCoreAppPackageVersionWithTilde Condition=" '$(MicrosoftNETCoreAppVersionPreReleaseSeparator)' != -1 ">$(MicrosoftNETCoreAppMajorMinorPatchVersion)~$(MicrosoftNETCoreVersionSuffix)</MicrosoftNETCoreAppPackageVersionWithTilde>
 
       <NetStandardTargetingPackVersionPreReleaseSeparator>$(NETStandardLibraryRefPackageVersion.IndexOf('-'))</NetStandardTargetingPackVersionPreReleaseSeparator>
       <NetStandardTargetingPackMajorMinorPatchVersion>$(NETStandardLibraryRefPackageVersion)</NetStandardTargetingPackMajorMinorPatchVersion>
       <NetStandardTargetingPackMajorMinorPatchVersion Condition=" '$(NetStandardTargetingPackVersionPreReleaseSeparator)' != -1 ">$(NETStandardLibraryRefPackageVersion.Substring(0, $(NetStandardTargetingPackVersionPreReleaseSeparator)))</NetStandardTargetingPackMajorMinorPatchVersion>
       <NetStandardTargetingPackVersionPreReleaseSeparatorStartIndex>$([MSBuild]::Add($(NetStandardTargetingPackVersionPreReleaseSeparator), 1))</NetStandardTargetingPackVersionPreReleaseSeparatorStartIndex>
       <NetStandardTargetingPackVersionSuffix Condition=" '$(NetStandardTargetingPackVersionPreReleaseSeparator)' != -1 ">$(NETStandardLibraryRefPackageVersion.Substring($(NetStandardTargetingPackVersionPreReleaseSeparatorStartIndex)))</NetStandardTargetingPackVersionSuffix>
-      <NetStandardTargetingPackPackageVersionWithTilda>$(NetStandardTargetingPackMajorMinorPatchVersion)</NetStandardTargetingPackPackageVersionWithTilda>
-      <NetStandardTargetingPackPackageVersionWithTilda Condition=" '$(NetStandardTargetingPackVersionPreReleaseSeparator)' != -1 ">$(NetStandardTargetingPackMajorMinorPatchVersion)~$(NetStandardTargetingPackVersionSuffix)</NetStandardTargetingPackPackageVersionWithTilda>
+      <NetStandardTargetingPackPackageVersionWithTilde>$(NetStandardTargetingPackMajorMinorPatchVersion)</NetStandardTargetingPackPackageVersionWithTilde>
+      <NetStandardTargetingPackPackageVersionWithTilde Condition=" '$(NetStandardTargetingPackVersionPreReleaseSeparator)' != -1 ">$(NetStandardTargetingPackMajorMinorPatchVersion)~$(NetStandardTargetingPackVersionSuffix)</NetStandardTargetingPackPackageVersionWithTilde>
 
       <AspNetCoreVersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCoreVersion.IndexOf('.')), 1))</AspNetCoreVersionPatchSeparatorIndex>
       <AspNetCoreVersionPatchSeparatorIndex>$(AspNetCoreVersion.IndexOf('.', $(AspNetCoreVersionPatchSeparatorIndex)))</AspNetCoreVersionPatchSeparatorIndex>
@@ -31,8 +31,8 @@
       <AspNetCoreMajorMinorPatchVersion Condition=" '$(AspNetCoreVersionPreReleaseSeparator)' != -1 ">$(AspNetCoreVersion.Substring(0, $(AspNetCoreVersionPreReleaseSeparator)))</AspNetCoreMajorMinorPatchVersion>
       <AspNetCoreVersionPreReleaseSeparatorStartIndex>$([MSBuild]::Add($(AspNetCoreVersionPreReleaseSeparator), 1))</AspNetCoreVersionPreReleaseSeparatorStartIndex>
       <AspNetCoreVersionSuffix Condition=" '$(AspNetCoreVersionPreReleaseSeparator)' != -1 ">$(AspNetCoreVersion.Substring($(AspNetCoreVersionPreReleaseSeparatorStartIndex)))</AspNetCoreVersionSuffix>
-      <AspNetCoreVersionWithTilda>$(AspNetCoreMajorMinorPatchVersion)</AspNetCoreVersionWithTilda>
-      <AspNetCoreVersionWithTilda Condition=" '$(AspNetCoreVersionPreReleaseSeparator)' != -1 ">$(AspNetCoreMajorMinorPatchVersion)~$(AspNetCoreVersionSuffix)</AspNetCoreVersionWithTilda>
+      <AspNetCoreVersionWithTilde>$(AspNetCoreMajorMinorPatchVersion)</AspNetCoreVersionWithTilde>
+      <AspNetCoreVersionWithTilde Condition=" '$(AspNetCoreVersionPreReleaseSeparator)' != -1 ">$(AspNetCoreMajorMinorPatchVersion)~$(AspNetCoreVersionSuffix)</AspNetCoreVersionWithTilde>
 
       <HostFxrVersionPatchSeparatorIndex>$([MSBuild]::Add($(HostFxrVersion.IndexOf('.')), 1))</HostFxrVersionPatchSeparatorIndex>
       <HostFxrVersionPatchSeparatorIndex>$(HostFxrVersion.IndexOf('.', $(HostFxrVersionPatchSeparatorIndex)))</HostFxrVersionPatchSeparatorIndex>


### PR DESCRIPTION
The resource branding for MicrosoftNETCoreApp and the Windows desktop runtime does not come from the same properties any longer.  Use appropriate properties instead.