### PR TITLE
[release/3.0.1xx] Fix "you are using a preview version" message

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -34,7 +34,7 @@
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
       <_NETStandardTargetFrameworkVersion>$(_NETStandardLibraryPackageVersion.Split('.')[0]).$(_NETStandardLibraryPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
 
-      <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
+      <NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</NETCoreSdkIsPreview>
     </PropertyGroup>
 
     <!-- Download "metapackages" for each shared framework in order to get the list of runtime identifers
@@ -165,7 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledRuntimeIdentifierGraphFile>%24(MSBuildThisFileDirectory)RuntimeIdentifierGraph.json</BundledRuntimeIdentifierGraphFile>
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <NETCoreSdkRuntimeIdentifier>$(ProductMonikerRid)</NETCoreSdkRuntimeIdentifier>
-    <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
+    <_NETCoreSdkIsPreview>$(NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
   </PropertyGroup>
   <ItemGroup>
     @(ImplicitPackageVariable->'<ImplicitPackageReferenceVersion Include="%(Identity)" TargetFrameworkVersion="%(TargetFrameworkVersion)" DefaultVersion="%(DefaultVersion)" LatestVersion="%(LatestVersion)"/>', '


### PR DESCRIPTION
The property in the bundled version props file installed with the SDK is _NETCoreSdkIsPreview. We use the same property name to define this value when creating the props file. We build with a preview version of the SDK. Because this is set by the preview SDK, and already has a value, we will not reset it when DropSuffix=true. It will simply remain 'true'. Thus we will simply propagate that existing value into the new props file.  To fix, change the property name.
