### PR TITLE
Updating branding to 3.0.1-servicing

### DIFF
--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -3,12 +3,11 @@
     <VersionMajor>3</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionPatch>00</VersionPatch>
-    <ReleaseSuffix Condition=" '$(ReleaseSuffix)' == '' ">rc2</ReleaseSuffix>
+    <VersionPatch>01</VersionPatch>
+    <ReleaseSuffix Condition=" '$(ReleaseSuffix)' == '' ">servicing</ReleaseSuffix>
     <!--
         When DropSuffix is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <DropSuffix>true</DropSuffix>
   </PropertyGroup>
   
   <Target Name="GetCoreSdkGitCommitInfo">

--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -8,6 +8,7 @@
     <!--
         When DropSuffix is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
+    <DropSuffix>false</DropSuffix>
   </PropertyGroup>
   
   <Target Name="GetCoreSdkGitCommitInfo">


### PR DESCRIPTION
Also removed the DropSuffix so that we stop producing final branded builds for now.
