### PR TITLE
Use dotnet/windowsdesktop official build outputs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,8 +2,8 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Winforms / WPF -->
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19503.13">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19503.55">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>21049ddbb7aa7e3e46451aeedd74444a6c931058</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19503.13">
@@ -54,7 +54,7 @@
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>93e85afea76586f82c10054db198421671cfde40</Sha>
     </Dependency>
-    <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via core setup -->
+    <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-alpha1.19502.3" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>2fb40d0baf02c4137cdfaab55e4dfd02919dcc9b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,10 +53,10 @@
     <NetCoreAppTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppTargetingPackVersion>
     <NetCoreAppHostPackVersion>$(MicrosoftNETCoreAppPackageVersion)</NetCoreAppHostPackVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-alpha1.19503.13</NETStandardLibraryRefPackageVersion>
-    <WindowsDesktopTargetingPackVersion>$(MicrosoftNETCoreAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <AspNetCoreVersion>$(MicrosoftAspNetCoreAppRuntimeWinX64PackageVersion)</AspNetCoreVersion>
     <AspNetTargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</AspNetTargetingPackVersion>
-    <MicrosoftWindowsDesktopAppPackageVersion>5.0.0-alpha1.19503.13</MicrosoftWindowsDesktopAppPackageVersion>
+    <MicrosoftWindowsDesktopAppPackageVersion>5.0.0-alpha1.19503.55</MicrosoftWindowsDesktopAppPackageVersion>
+    <WindowsDesktopTargetingPackVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</WindowsDesktopTargetingPackVersion>
     <MicrosoftWindowsDesktopPackageVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</MicrosoftWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -70,7 +70,7 @@
     <PropertyGroup>
       <CoreSetupRootUrl>$(CoreSetupBlobRootUrl)Runtime/</CoreSetupRootUrl>
       <AspNetCoreSharedFxRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/Runtime/</AspNetCoreSharedFxRootUrl>
-      <WinFormsAndWpfSharedFxRootUrl>$(CoreSetupRootUrl)</WinFormsAndWpfSharedFxRootUrl>
+      <WinFormsAndWpfSharedFxRootUrl>$(CoreSetupBlobRootUrl)WindowsDesktop/</WinFormsAndWpfSharedFxRootUrl>
       <CoreSetupDownloadDirectory>$(IntermediateDirectory)/coreSetupDownload/$(MicrosoftNETCoreAppPackageVersion)</CoreSetupDownloadDirectory>
       <CombinedSharedHostAndFrameworkArchive>$(CoreSetupDownloadDirectory)/combinedSharedHostAndFrameworkArchive$(ArchiveExtension)</CombinedSharedHostAndFrameworkArchive>
     </PropertyGroup>
@@ -174,7 +174,7 @@
 
       <BundledInstallerComponent Include="DownloadedWindowsDesktopTargetingPackInstallerFile"
                                  Condition="'$(InstallerExtension)' == '.msi' And '$(SkipBuildingInstallers)' != 'true' And !$(Architecture.StartsWith('arm'))">
-        <BaseUrl>$(CoreSetupRootUrl)$(WindowsDesktopTargetingPackVersion)</BaseUrl>
+        <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopTargetingPackVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWindowsDesktopTargetingPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>


### PR DESCRIPTION
The WindowsDesktop shared framework is moving from dotnet/core-setup to dotnet/windowsdesktop. This is a test PR to see if the official build I have set up for dotnet/windowsdesktop will work--it should not be be merged.

Once WindowsDesktop is deleted from dotnet/core-setup, this change has to be made in sync to switch over to getting dependencies from the dotnet/windowsdesktop repo. Unfortunately there's no smooth migration flow, and we would need new features in Maestro++/Darc to allow it.