### PR TITLE
Augment DownloadFile task to make it able to download from public/private location

### DIFF
--- a/src/core-sdk-tasks/DownloadFile.cs
+++ b/src/core-sdk-tasks/DownloadFile.cs
@@ -50,23 +50,30 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 Log.LogMessage(MessageImportance.High, $"Downloading '{Uri}' to '{DestinationPath}'");
 
-                if (!DownloadFile(Uri, DestinationPath))
+                if (!DownloadFromUri(Uri, DestinationPath))
                 {
                     if (!string.IsNullOrWhiteSpace(PrivateUri))
                     {
-                        return DownloadFile(PrivateUri, DestinationPath);
+                        Log.LogMessage(MessageImportance.High, $"Couldn't download file '{Uri}' to '{DestinationPath}'. Trying to download file from '{PrivateUri}' instead.");
+
+                        if (!DownloadFromUri(PrivateUri, DestinationPath))
+                        {
+                            Log.LogError($"Couldn't download file '{PrivateUri}' to '{DestinationPath}' either.");
+                            return false;
+                        }
                     }
-
-                    Log.LogError($"Couldn't download file '{Uri}' to '{DestinationPath}'");
-
-                    return false;
+                    else
+                    {
+                        Log.LogError($"Couldn't download file '{Uri}' to '{DestinationPath}'");
+                        return false;
+                    }
                 }
             }
 
             return true;
         }
 
-        private bool DownloadFile(string source, string target)
+        private bool DownloadFromUri(string source, string target)
         {
             try
             {

--- a/src/core-sdk-tasks/DownloadFile.cs
+++ b/src/core-sdk-tasks/DownloadFile.cs
@@ -14,6 +14,12 @@ namespace Microsoft.DotNet.Cli.Build
         [Required]
         public string Uri { get; set; }
 
+        /// <summary>
+        /// If this field is set and the task fail to download the file from `Uri` it will try
+        /// to download the file from `PrivateUri`.
+        /// </summary>
+        public string PrivateUri { get; set; }
+
         [Required]
         public string DestinationPath { get; set; }
 
@@ -44,26 +50,40 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 Log.LogMessage(MessageImportance.High, $"Downloading '{Uri}' to '{DestinationPath}'");
 
-                using (var httpClient = new HttpClient())
+                if (!DownloadFile(Uri, DestinationPath))
                 {
-                    var getTask = httpClient.GetStreamAsync(Uri);
+                    if (!string.IsNullOrWhiteSpace(PrivateUri))
+                    {
+                        return DownloadFile(PrivateUri, DestinationPath);
+                    }
 
-                    try
-                    {
-                        using (var outStream = File.Create(DestinationPath))
-                        {
-                            getTask.Result.CopyTo(outStream);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        File.Delete(DestinationPath);
-                        throw;
-                    }
+                    Log.LogError($"Couldn't download file '{Uri}' to '{DestinationPath}'");
+
+                    return false;
                 }
             }
 
             return true;
+        }
+
+        private bool DownloadFile(string source, string target)
+        {
+            try
+            {
+                using (var httpClient = new HttpClient())
+                using (var outStream = File.Create(target))
+                {
+                    var getTask = httpClient.GetStreamAsync(source);
+                    getTask.Result.CopyTo(outStream);
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                File.Delete(target);
+                return false;
+            }
         }
     }
 }

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -397,7 +397,7 @@
       <BundledLayoutPackage>
         <LoweredPackageName>$([MSBuild]::ValueOrDefault('%(BundledLayoutPackage.PackageName)', '').ToLower())</LoweredPackageName>
       </BundledLayoutPackage>
-
+      
       <BundledLayoutPackageDownloadFiles Include="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\**\*.*">
         <RelativeLayoutPath>%(BundledLayoutPackage.RelativeLayoutPath)</RelativeLayoutPath>
         <LayoutPackageDescription>%(BundledLayoutPackage.Identity)</LayoutPackageDescription>
@@ -462,7 +462,7 @@
   </Target>
 
   <Target Name="LayoutAppHostTemplate" DependsOnTargets="RunResolvePackageDependencies">
-
+    
     <PropertyGroup>
       <NETCoreDotNetAppHostPackageName>Microsoft.NETCore.App.Host.$(SharedFrameworkRid)</NETCoreDotNetAppHostPackageName>
       <AppHostRestorePath>$(IntermediateOutputPath)AppHostRestore\</AppHostRestorePath>
@@ -488,7 +488,7 @@
       BuildInParallel="False"
       Projects="@(AppHostTemplateDownloadPackageProject)">
     </MSBuild>
-
+    
     <PropertyGroup>
       <AppHostExecutableName>AppHost$(ExeExtension)</AppHostExecutableName>
     </PropertyGroup>
@@ -535,7 +535,7 @@
 
     <RemoveDir Directories="$(SdkInternalLayoutPath)" />
     <MakeDir Directories="$(SdkInternalLayoutPath)" />
-
+    
     <!-- Create "SDK Internal" layout to create the MSI to bundle -->
     <ItemGroup>
       <SdkInternalFiles Include="$(RedistLayoutPath)sdk/$(SdkVersion)/**/*.*"/>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -19,17 +19,17 @@
   <Target Name="SetupBundledComponents" DependsOnTargets="GetCurrentRuntimeInformation;SetupFileExtensions;SetSdkVersionInfo;SetBuildDefaults">
     <PropertyGroup>
       <SdkOutputDirectory>$(RedistLayoutPath)sdk\$(SdkVersion)\</SdkOutputDirectory>
-      
+
       <InternalBuild Condition="$(SYSTEM_TEAMPROJECT) == 'internal' and $(BUILD_SOURCEBRANCH.ToLower().contains('internal'))">true</InternalBuild>
       <CoreSetupBlobAccessTokenParam Condition="'$(InternalBuild)' == 'true'">$(DOTNETCLIMSRC_READ_SAS_TOKEN)</CoreSetupBlobAccessTokenParam>
 
-      <CoreSetupBlobRootUrl Condition="'$(CoreSetupBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</CoreSetupBlobRootUrl>
+      <PrivateCoreSetupBlobRootUrl Condition="'$(PrivateCoreSetupBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</PrivateCoreSetupBlobRootUrl>
       <CoreSetupBlobRootUrl Condition="'$(CoreSetupBlobRootUrl)' == ''">https://dotnetcli.azureedge.net/dotnet/</CoreSetupBlobRootUrl>
 
-      <DotnetExtensionsBlobRootUrl Condition="'$(DotnetExtensionsBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</DotnetExtensionsBlobRootUrl>
+      <PrivateDotnetExtensionsBlobRootUrl Condition="'$(PrivateDotnetExtensionsBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</PrivateDotnetExtensionsBlobRootUrl>
       <DotnetExtensionsBlobRootUrl Condition="'$(DotnetExtensionsBlobRootUrl)' == ''">https://dotnetcli.blob.core.windows.net/dotnet/</DotnetExtensionsBlobRootUrl>
-      
-      <DotnetToolsetBlobRootUrl Condition="'$(DotnetToolsetBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</DotnetToolsetBlobRootUrl>
+
+      <PrivateDotnetToolsetBlobRootUrl Condition="'$(PrivateDotnetToolsetBlobRootUrl)' == '' and '$(InternalBuild)' == 'true'">https://dotnetclimsrc.blob.core.windows.net/dotnet/</PrivateDotnetToolsetBlobRootUrl>
       <DotnetToolsetBlobRootUrl Condition="'$(DotnetToolsetBlobRootUrl)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-toolset/</DotnetToolsetBlobRootUrl>
 
       <CoreSetupRid Condition="'$(CoreSetupRid)' == ''">$(HostRid)</CoreSetupRid>
@@ -91,8 +91,14 @@
 
     <PropertyGroup>
       <CoreSetupRootUrl>$(CoreSetupBlobRootUrl)Runtime/</CoreSetupRootUrl>
+      <PrivateCoreSetupRootUrl>$(PrivateCoreSetupBlobRootUrl)Runtime/</PrivateCoreSetupRootUrl>
+
       <AspNetCoreSharedFxRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/Runtime/</AspNetCoreSharedFxRootUrl>
-      <WinFormsAndWpfSharedFxRootUrl>$(CoreSetupBlobRootUrl)WindowsDesktop/</WinFormsAndWpfSharedFxRootUrl>
+      <PrivateAspNetCoreSharedFxRootUrl>$(PrivateCoreSetupBlobRootUrl)aspnetcore/Runtime/</PrivateAspNetCoreSharedFxRootUrl>
+
+      <WinFormsAndWpfSharedFxRootUrl>$(CoreSetupRootUrl)</WinFormsAndWpfSharedFxRootUrl>
+      <PrivateWinFormsAndWpfSharedFxRootUrl>$(PrivateCoreSetupRootUrl)</PrivateWinFormsAndWpfSharedFxRootUrl>
+
       <CoreSetupDownloadDirectory>$(IntermediateDirectory)/coreSetupDownload/$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</CoreSetupDownloadDirectory>
       <CombinedSharedHostAndFrameworkArchive>$(CoreSetupDownloadDirectory)/combinedSharedHostAndFrameworkArchive$(ArchiveExtension)</CombinedSharedHostAndFrameworkArchive>
     </PropertyGroup>
@@ -106,6 +112,7 @@
     <ItemGroup>
       <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
         <RelativeLayoutPath></RelativeLayoutPath>
@@ -163,6 +170,7 @@
       <BundledInstallerComponent Include="DownloadedRuntimeDepsInstallerFile"
                                  Condition="('$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true') And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedRuntimeDepsInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -170,6 +178,7 @@
       <BundledInstallerComponent Include="DownloadedSharedFrameworkInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedSharedFrameworkInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -177,6 +186,7 @@
       <BundledInstallerComponent Include="DownloadedSharedHostInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(SharedHostVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(SharedHostVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedSharedHostInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -184,6 +194,7 @@
       <BundledInstallerComponent Include="DownloadedHostFxrInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(HostFxrVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(HostFxrVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedHostFxrInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -191,6 +202,7 @@
       <BundledInstallerComponent Include="DownloadedNetCoreAppTargetingPackInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(NetCoreAppTargetingPackVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(NetCoreAppTargetingPackVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppTargetingPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -199,6 +211,7 @@
                            Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <!-- NetStandard targeting pack currently frozen at 2.1.0 from 3.0.0 branch -->
         <BaseUrl>$(CoreSetupRootUrl)3.0.0</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)3.0.0</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedNetStandardTargetingPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -206,6 +219,7 @@
       <BundledInstallerComponent Include="DownloadedNetCoreAppHostPackInstallerFile"
                      Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppHostPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -213,6 +227,7 @@
       <BundledInstallerComponent Include="DownloadedAlternateNetCoreAppHostPackInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedAlternateNetCoreAppHostPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -220,6 +235,7 @@
       <BundledInstallerComponent Include="DownloadedArmNetCoreAppHostPackInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedArmNetCoreAppHostPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -227,19 +243,22 @@
       <BundledInstallerComponent Include="DownloadedArm64NetCoreAppHostPackInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedArm64NetCoreAppHostPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedWindowsDesktopTargetingPackInstallerFile"
                                  Condition="'$(InstallerExtension)' == '.msi' And '$(SkipBuildingInstallers)' != 'true' And !$(Architecture.StartsWith('arm'))">
-        <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopTargetingPackVersion)</BaseUrl>
+        <BaseUrl>$(CoreSetupRootUrl)$(WindowsDesktopTargetingPackVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateCoreSetupRootUrl)$(WindowsDesktopTargetingPackVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedWindowsDesktopTargetingPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
 
       <BundledLayoutComponent Include="ToolsetArchive">
         <BaseUrl>$(DotnetToolsetBlobRootUrl)Toolset/$(MicrosoftDotnetToolsetInternalPackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateDotnetToolsetBlobRootUrl)Toolset/$(MicrosoftDotnetToolsetInternalPackageVersion)</PrivateBaseUrl>
         <DownloadFileName>dotnet-toolset-internal-$(MicrosoftDotnetToolsetInternalPackageVersion).zip</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
         <RelativeLayoutPath>sdk/$(SdkVersion)</RelativeLayoutPath>
@@ -249,6 +268,7 @@
     <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
       <BundledLayoutComponent Include="DownloadedAspNetCoreSharedFxArchiveFile">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(AspNetCoreSharedFxArchiveFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
         <RelativeLayoutPath></RelativeLayoutPath>
@@ -259,6 +279,7 @@
       <BundledLayoutComponent Include="DownloadedAspNetTargetingPackArchiveFile"
                               Condition="'$(InstallerExtension)' == '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(AspNetTargetingPackArchiveFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
         <RelativeLayoutPath></RelativeLayoutPath>
@@ -267,6 +288,7 @@
       <BundledInstallerComponent Include="DownloadedAspNetTargetingPackInstallerFile"
                                  Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedAspNetTargetingPackInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -274,6 +296,7 @@
       <BundledInstallerComponent Include="DownloadedAspNetCoreSharedFxInstallerFile"
                                  Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedAspNetCoreSharedFxInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -281,6 +304,7 @@
       <BundledInstallerComponent Include="DownloadedAspNetCoreSharedFxWixLibFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedAspNetCoreSharedFxWixLibFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -288,6 +312,7 @@
       <BundledInstallerComponent Include="DownloadedAspNetCoreV2ModuleInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedAspNetCoreV2ModuleInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -295,6 +320,7 @@
       <BundledInstallerComponent Include="AspNetCoreSharedFxBaseRuntimeVersionFile"
                                  Condition="!$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateAspNetCoreSharedFxRootUrl)$(AspNetCoreBlobDirectory)</PrivateBaseUrl>
         <DownloadFileName>$(AspNetCoreSharedFxBaseRuntimeVersionFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -316,6 +342,7 @@
 
       <BundledLayoutComponent Include="WinFormsAndWpfSharedFxArchiveFile">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateWinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledLayoutComponent>
@@ -323,6 +350,7 @@
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</BaseUrl>
+        <PrivateBaseUrl>$(PrivateWinFormsAndWpfSharedFxRootUrl)$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</PrivateBaseUrl>
         <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
         <AccessToken>$(CoreSetupBlobAccessTokenParam)</AccessToken>
       </BundledInstallerComponent>
@@ -344,7 +372,8 @@
     </ItemGroup>
 
     <DownloadFile Condition=" '@(ComponentToDownload)' != '' And '%(ComponentToDownload.ShouldDownload)' == 'true'"
-                  Uri="%(ComponentToDownload.BaseUrl)/%(ComponentToDownload.DownloadFileName)%(ComponentToDownload.AccessToken)"
+                  Uri="%(ComponentToDownload.BaseUrl)/%(ComponentToDownload.DownloadFileName)"
+                  PrivateUri="%(ComponentToDownload.PrivateBaseUrl)/%(ComponentToDownload.DownloadFileName)%(ComponentToDownload.AccessToken)"
                   DestinationPath="%(ComponentToDownload.DownloadDestination)" />
 
     <ItemGroup>
@@ -368,7 +397,7 @@
       <BundledLayoutPackage>
         <LoweredPackageName>$([MSBuild]::ValueOrDefault('%(BundledLayoutPackage.PackageName)', '').ToLower())</LoweredPackageName>
       </BundledLayoutPackage>
-      
+
       <BundledLayoutPackageDownloadFiles Include="$(NuGetPackageRoot)\%(BundledLayoutPackage.LoweredPackageName)\%(BundledLayoutPackage.PackageVersion)\**\*.*">
         <RelativeLayoutPath>%(BundledLayoutPackage.RelativeLayoutPath)</RelativeLayoutPath>
         <LayoutPackageDescription>%(BundledLayoutPackage.Identity)</LayoutPackageDescription>
@@ -433,7 +462,7 @@
   </Target>
 
   <Target Name="LayoutAppHostTemplate" DependsOnTargets="RunResolvePackageDependencies">
-    
+
     <PropertyGroup>
       <NETCoreDotNetAppHostPackageName>Microsoft.NETCore.App.Host.$(SharedFrameworkRid)</NETCoreDotNetAppHostPackageName>
       <AppHostRestorePath>$(IntermediateOutputPath)AppHostRestore\</AppHostRestorePath>
@@ -459,7 +488,7 @@
       BuildInParallel="False"
       Projects="@(AppHostTemplateDownloadPackageProject)">
     </MSBuild>
-    
+
     <PropertyGroup>
       <AppHostExecutableName>AppHost$(ExeExtension)</AppHostExecutableName>
     </PropertyGroup>
@@ -506,7 +535,7 @@
 
     <RemoveDir Directories="$(SdkInternalLayoutPath)" />
     <MakeDir Directories="$(SdkInternalLayoutPath)" />
-    
+
     <!-- Create "SDK Internal" layout to create the MSI to bundle -->
     <ItemGroup>
       <SdkInternalFiles Include="$(RedistLayoutPath)sdk/$(SdkVersion)/**/*.*"/>


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/4164
Related to: https://github.com/dotnet/arcade/issues/3868

Make `DownloadFile` receive a new parameter called `PrivateUri` which should contain a secondary URL to use for downloading a file in case the download from `Uri` fail.

[Tested restoring from public location.](https://dnceng.visualstudio.com/internal/_build/results?buildId=397738&view=results)
[Tested restoring from _private_ location.](https://dnceng.visualstudio.com/internal/_build/results?buildId=399879&view=results)


/cc @livarcocc @mmitche @riarenas @dagood