### PR TITLE
Update NUnit3.DotNetNew.Template bundled versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
-    <NUnit3DotNetNewTemplatePackageVersion>1.6.3</NUnit3DotNetNewTemplatePackageVersion>
+    <NUnit3DotNetNewTemplatePackageVersion>1.7.0</NUnit3DotNetNewTemplatePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
@@ -93,7 +93,7 @@
     <!-- 3.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>4.8.0-rc2.19462.10</MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates30PackageVersion>3.0.0</MicrosoftDotNetWpfProjectTemplates30PackageVersion>
-    <NUnit3Templates30PackageVersion>1.6.3</NUnit3Templates30PackageVersion>
+    <NUnit3Templates30PackageVersion>1.6.4</NUnit3Templates30PackageVersion>
     <MicrosoftDotNetCommonItemTemplates30PackageVersion>2.0.0-preview8.19373.1</MicrosoftDotNetCommonItemTemplates30PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplates30PackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
     <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.19354.2</MicrosoftDotNetTestProjectTemplates30PackageVersion>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -124,7 +124,7 @@
 
     <PackageDownload Update="Microsoft.DotNet.Common.ItemTemplates"
                      Version="[$(MicrosoftDotNetCommonItemTemplates21PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates22PackageVersion)]; 
+                              [$(MicrosoftDotNetCommonItemTemplates22PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates30PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates31PackageVersion)];
                               " />
@@ -145,14 +145,15 @@
                      Version="[$(NUnit3Templates21PackageVersion)];
                               [$(NUnit3Templates22PackageVersion)];
                               [$(NUnit3Templates30PackageVersion)];
+                              [$(NUnit3Templates31PackageVersion)];
                               " />
 
-   <PackageDownload Update="Microsoft.Dotnet.Wpf.ProjectTemplates" 
+   <PackageDownload Update="Microsoft.Dotnet.Wpf.ProjectTemplates"
                     Version="[$(MicrosoftDotnetWpfProjectTemplates30PackageVersion)];
                              [$(MicrosoftDotnetWpfProjectTemplates31PackageVersion)];
                              " />
 
-    <PackageDownload Update="Microsoft.Dotnet.Winforms.ProjectTemplates" 
+    <PackageDownload Update="Microsoft.Dotnet.Winforms.ProjectTemplates"
                      Version="[$(MicrosoftDotnetWinFormsProjectTemplates30PackageVersion)];
                               [$(MicrosoftDotnetWinFormsProjectTemplates31PackageVersion)];
                              " />
@@ -160,7 +161,7 @@
 
   <Target Name="LayoutTemplates"
         DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor22MSI;LayoutTemplatesFor21MSI" />
-    
+
   <Target Name="LayoutTemplatesForSDK"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">


### PR DESCRIPTION
This PR updates versions for bundled [NUnit3.DotNetNew.Template](https://www.nuget.org/packages/NUnit3.DotNetNew.Template/) nuget package:

- issued new v1.6.4 for .NET Core 3 with updated dependencies versions (see https://github.com/nunit/dotnet-new-nunit/pull/29)
- issued new v1.7.0 wih support for .NET Core 3.1 targeting, netcoreapp3.1 is the default targeting since that version (see https://github.com/nunit/dotnet-new-nunit/pull/30)
