### PR TITLE
Switch to hosted pool to reduce restore difficulties

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,8 +32,7 @@ stages:
       agentOs: Windows_NT
       pool:
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2017.open
+          vmImage: vs2017-win2016
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: NetCoreInternal-Pool
           queue: buildpool.windows.10.amd64.vs2017


### PR DESCRIPTION
The hosted pools have better restore performance owing to the fact that they do not have throttling issues with AzDO.  Switch to these temporarily while we resolve the issues