### PR TITLE
Update PreReleaseVersionLabel to RTM

### DIFF
--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -4,7 +4,7 @@
     <VersionMinor>1</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
     <VersionPatch>00</VersionPatch>
-    <ReleaseSuffix Condition=" '$(ReleaseSuffix)' == '' ">preview3</ReleaseSuffix>
+    <ReleaseSuffix Condition=" '$(ReleaseSuffix)' == '' ">rtm</ReleaseSuffix>
     <!--
         When DropSuffix is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->


### PR DESCRIPTION
Non-shipping packages should be labeled RTM for GA. We need to take this fix for 3.1 GA

@dsplaisted @mmitche @livarcocc PTAL