### PR TITLE
Change copy-to-latest dependencies

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -264,11 +264,7 @@ stages:
     dependsOn:
       # This will run only after all the publishing stages have run.
       # These stages are introduced in the eng/common/templates/post-build/channels YAML templates
-      - NetCore_Dev31_Publish
       - NetCore_Dev5_Publish
-      - NetCore_Release30_Publish
-      - NetCore_Release31_Publish
-      - PVR_Publish
     jobs:
     - job: Copy_SDK_To_Latest
       pool:


### PR DESCRIPTION
Remove the dependency on release channels (and the validation channel, which should not be used by core-sdk) in master, where we should never publish to those channels.  This is to get ready for https://github.com/dotnet/arcade/pull/4373. which will remove these stages from the build.