### PR TITLE
Bump 3.0 packs to 3.0.1 as appropriate

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,9 @@
     <add key="darc-pub-dotnet-corefx-0f7f38c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-0f7f38c4/nuget/v3/index.json" />
     <add key="darc-pub-aspnet-AspNetCore-2b7e994" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-AspNetCore-2b7e994b/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="darc-pub-aspnet-AspNetCore-22dedcb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-AspNetCore-22dedcb2/nuget/v3/index.json" />
+    <!-- 3.0.1 assets are needed and not on nuget.org yet or other feeds below. Darc cannot see that due to nonstandard way these are pulled in to a non-3.0 branch -->
+    <add key="AspNetCore-3-0-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-AspNetCore-22dedcb2/nuget/v3/index.json" />
+    <add key="core-setup-3-0-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-32085cbc/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
@@ -27,5 +29,8 @@
   </packageSources>
   <disabledPackageSources>
     <clear />
+    <!-- Added by darc above. due to dependencies on 3.0.0 and 2.1.0 packs, but we can get those from nuget.org -->
+    <!-- Darc will just put it back if we attempt to remove it above. -->
+    <add key="darc-pub-dotnet-core-setup-7d57652" value="true" />
   </disabledPackageSources>
 </configuration>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -14,12 +14,12 @@
       <_NETStandardLibraryPackageVersion>$(NETStandardLibraryRefPackageVersion)</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
-      <_NETCoreApp30PRuntimePackVersion>3.0.0</_NETCoreApp30PRuntimePackVersion>
+      <_NETCoreApp30RuntimePackVersion>3.0.1</_NETCoreApp30RuntimePackVersion>
       <_NETCoreApp30TargetingPackVersion>3.0.0</_NETCoreApp30TargetingPackVersion>
-      <_WindowsDesktop30RuntimePackVersion>$(_NETCoreApp30PRuntimePackVersion)</_WindowsDesktop30RuntimePackVersion>
-      <_WindowsDesktop30TargetingPackVersion>$(_NETCoreApp30TargetingPackVersion)</_WindowsDesktop30TargetingPackVersion>
-      <_AspNet30RuntimePackVersion>3.0.0</_AspNet30RuntimePackVersion>
-      <_AspNet30TargetingPackVersion>3.0.0</_AspNet30TargetingPackVersion>
+      <_WindowsDesktop30RuntimePackVersion>3.0.1</_WindowsDesktop30RuntimePackVersion>
+      <_WindowsDesktop30TargetingPackVersion>3.0.0</_WindowsDesktop30TargetingPackVersion>
+      <_AspNet30RuntimePackVersion>3.0.1</_AspNet30RuntimePackVersion>
+      <_AspNet30TargetingPackVersion>3.0.1</_AspNet30TargetingPackVersion>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
@@ -226,7 +226,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetFramework="netcoreapp3.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
                               DefaultRuntimeFrameworkVersion="3.0.0"
-                              LatestRuntimeFrameworkVersion="$(_NETCoreApp30PRuntimePackVersion)"
+                              LatestRuntimeFrameworkVersion="$(_NETCoreApp30RuntimePackVersion)"
                               TargetingPackName="Microsoft.NETCore.App.Ref"
                               TargetingPackVersion="$(_NETCoreApp30TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
@@ -237,7 +237,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownAppHostPack Include="Microsoft.NETCore.App"
                       TargetFramework="netcoreapp3.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-                      AppHostPackVersion="$(_NETCoreApp30PRuntimePackVersion)"
+                      AppHostPackVersion="$(_NETCoreApp30RuntimePackVersion)"
                       AppHostRuntimeIdentifiers="@(NetCore30RuntimePackRids, '%3B')"
                       />
     


### PR DESCRIPTION
### Description

The 3.1 SDK does not use 3.0.1 runtime and targeting packs as appropriate when targeting 3.0.


### Customer impact

1. Self-contained 3.0 apps built with 3.1 SDK will be deployed with 3.0.0 runtimes instead of 3.0.1 runtime
2. Bug fixed in ASP.NET 3.0.1 targeting pack (missing type forwards), will not be fixed by SDK 3.1.100 as it is by SDK 3.0.101

### Regression

From customer perspective, yes, as this will be perceived as scenarios 1 and 2 working in 3.0.101 SDK and not 3.1.100 SDK.

### Risk

Low.

### Tests

Diffed the bundled versions props file between 3.0.101 and 3.1.100 to confirm that the 3.0 sections are now identical. dotnet/sdk tests that run in CI stressed this scenario as well, as evidenced by needing to add a nuget feed to find 3.0.1 runtime pack once this change was applied (The challenge is that 3.0.1 and 3.1.0 are shipping days apart so 3.0.1 assets aren't on nuget.or yet.)
