### PR TITLE
Updated all MSIs to use the GenerateMsiVersion task

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,6 @@
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
-    <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel)$(PreReleaseVersionIteration)-$(_BuildNumberLabels)</FullNugetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/toolset -->

--- a/src/core-sdk-tasks/GenerateMsiVersionFromFullVersion.cs
+++ b/src/core-sdk-tasks/GenerateMsiVersionFromFullVersion.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GenerateMsiVersionFromFullVersion : Task
+    {
+        [Required]
+        public int VersionRevision { get; set; }
+
+        [Required]
+        public string VersionMajorMinorPatch { get; set; }
+
+        [Output]
+        public string MsiVersion { get; set; }
+
+        public override bool Execute()
+        {
+            var parsedVersion = NuGetVersion.Parse(VersionMajorMinorPatch);
+
+            var buildVersion = new Version()
+            {
+                Major = parsedVersion.Major,
+                Minor = parsedVersion.Minor,
+                Patch = parsedVersion.Patch,
+                VersionRevision = VersionRevision
+            };
+
+            MsiVersion = buildVersion.GenerateMsiVersion();
+
+            return true;
+        }
+    }
+}

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -26,6 +26,7 @@
   <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="TarGzFileCreateFromDirectory" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(CoreSdkTaskDll)" />
+  <UsingTask TaskName="GenerateMsiVersionFromFullVersion" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateGuidFromName" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="Chmod" AssemblyFile="$(CoreSdkTaskDll)" />

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -4,7 +4,6 @@
       <AspNetCore31VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor31Templates.IndexOf('-'))</AspNetCore31VersionPreReleaseSeparator>
       <AspNetCore31VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor31Templates)</AspNetCore31VersionMajorMinorPatchVersion>
       <AspNetCore31VersionMajorMinorPatchVersion Condition=" '$(AspNetCore31VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor31Templates.Substring(0, $(AspNetCore31VersionPreReleaseSeparator)))</AspNetCore31VersionMajorMinorPatchVersion>
-      <BundledTemplates31MSIVersion>$(AspNetCore31VersionMajorMinorPatchVersion).$(CombinedBuildNumberAndRevision)</BundledTemplates31MSIVersion>
       <BundledTemplates31InstallPath>$(AspNetCore31VersionMajorMinorPatchVersion)</BundledTemplates31InstallPath>
       <BundledTemplates31InstallPath Condition=" '$(AspNetCore31VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates31InstallPath)-$(VersionSuffix)</BundledTemplates31InstallPath>
       <Templates31VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore31VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates31VersionPatchSeparatorIndex>
@@ -14,7 +13,6 @@
       <AspNetCore30VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor30Templates.IndexOf('-'))</AspNetCore30VersionPreReleaseSeparator>
       <AspNetCore30VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor30Templates)</AspNetCore30VersionMajorMinorPatchVersion>
       <AspNetCore30VersionMajorMinorPatchVersion Condition=" '$(AspNetCore30VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor30Templates.Substring(0, $(AspNetCore30VersionPreReleaseSeparator)))</AspNetCore30VersionMajorMinorPatchVersion>
-      <BundledTemplates30MSIVersion>$(AspNetCore30VersionMajorMinorPatchVersion).$(CombinedBuildNumberAndRevision)</BundledTemplates30MSIVersion>
       <BundledTemplates30InstallPath>$(AspNetCore30VersionMajorMinorPatchVersion)</BundledTemplates30InstallPath>
       <BundledTemplates30InstallPath Condition=" '$(AspNetCore30VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates30InstallPath)-$(VersionSuffix)</BundledTemplates30InstallPath>
       <Templates30VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore30VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates30VersionPatchSeparatorIndex>
@@ -24,7 +22,6 @@
       <AspNetCore22VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor22Templates.IndexOf('-'))</AspNetCore22VersionPreReleaseSeparator>
       <AspNetCore22VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor22Templates)</AspNetCore22VersionMajorMinorPatchVersion>
       <AspNetCore22VersionMajorMinorPatchVersion Condition=" '$(AspNetCore22VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor22Templates.Substring(0, $(AspNetCore22VersionPreReleaseSeparator)))</AspNetCore22VersionMajorMinorPatchVersion>
-      <BundledTemplates22MSIVersion>$(AspNetCore22VersionMajorMinorPatchVersion).$(CombinedBuildNumberAndRevision)</BundledTemplates22MSIVersion>
       <BundledTemplates22InstallPath>$(AspNetCore22VersionMajorMinorPatchVersion)</BundledTemplates22InstallPath>
       <BundledTemplates22InstallPath Condition=" '$(AspNetCore22VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates22InstallPath)-$(VersionSuffix)</BundledTemplates22InstallPath>
       <Templates22VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore22VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates22VersionPatchSeparatorIndex>
@@ -34,13 +31,32 @@
       <AspNetCore21VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor21Templates.IndexOf('-'))</AspNetCore21VersionPreReleaseSeparator>
       <AspNetCore21VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor21Templates)</AspNetCore21VersionMajorMinorPatchVersion>
       <AspNetCore21VersionMajorMinorPatchVersion Condition=" '$(AspNetCore21VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor21Templates.Substring(0, $(AspNetCore21VersionPreReleaseSeparator)))</AspNetCore21VersionMajorMinorPatchVersion>
-      <BundledTemplates21MSIVersion>$(AspNetCore21VersionMajorMinorPatchVersion).$(CombinedBuildNumberAndRevision)</BundledTemplates21MSIVersion>
       <BundledTemplates21InstallPath>$(AspNetCore21VersionMajorMinorPatchVersion)</BundledTemplates21InstallPath>
       <BundledTemplates21InstallPath Condition=" '$(AspNetCore21VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates21InstallPath)-$(VersionSuffix)</BundledTemplates21InstallPath>
       <Templates21VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore21VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates21VersionPatchSeparatorIndex>
       <Templates21VersionPatchSeparatorIndex>$(AspNetCore21VersionMajorMinorPatchVersion.IndexOf('.', $(Templates21VersionPatchSeparatorIndex)))</Templates21VersionPatchSeparatorIndex>
       <BundledTemplates21MajorMinorVersion>$(AspNetCore21VersionMajorMinorPatchVersion.Substring(0, $(Templates21VersionPatchSeparatorIndex)))</BundledTemplates21MajorMinorVersion>
     </PropertyGroup>
+
+    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
+                                       VersionMajorMinorPatch="$(AspNetCore31VersionMajorMinorPatchVersion)">
+      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates31MSIVersion" />
+    </GenerateMsiVersionFromFullVersion>
+
+    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
+                                       VersionMajorMinorPatch="$(AspNetCore30VersionMajorMinorPatchVersion)">
+      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates30MSIVersion" />
+    </GenerateMsiVersionFromFullVersion>
+
+    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
+                                       VersionMajorMinorPatch="$(AspNetCore22VersionMajorMinorPatchVersion)">
+      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates22MSIVersion" />
+    </GenerateMsiVersionFromFullVersion>
+
+    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
+                                       VersionMajorMinorPatch="$(AspNetCore21VersionMajorMinorPatchVersion)">
+      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates21MSIVersion" />
+    </GenerateMsiVersionFromFullVersion>
   </Target>
 
   <ItemGroup>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -426,6 +426,13 @@
                       Overwrite="true" />
   </Target>
 
+  <Target Name="GenerateFullNuGetVersion">
+    <PropertyGroup>
+      <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</FullNugetVersion>
+      <FullNugetVersion Condition=" '$(VersionSuffixDateStamp)' != '' And '$(VersionSuffixBuildOfTheDay)' != '' ">$(FullNugetVersion).$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</FullNugetVersion>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="LayoutAppHostTemplate" DependsOnTargets="RunResolvePackageDependencies">
 
     <PropertyGroup>
@@ -481,6 +488,7 @@
           DependsOnTargets="DownloadBundledComponents;
                             CleanLayoutPath;
                             LayoutBundledComponents;
+                            GenerateFullNuGetVersion;
                             GenerateVersionFile;
                             GenerateBundledVersions;
                             LayoutRuntimeGraph;

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -71,7 +71,11 @@
       <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
       <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
       <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
-      <SDKBundleVersion>$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
+      
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->    
+      <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
+      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
+      <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Updated all MSIs to use the GenerateMsiVersion task and also moved the generation of FullNuGetVersion to a target because it depends on things happening in BeforeCommons.targets of Arcade.
