### PR TITLE
Fix publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -15,6 +15,8 @@
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" Condition=" '$(PublishSdkAssetsAndChecksumsToBlob)' == 'true' " />
+
+  <Import Project="..\src\redist\targets\Versions.targets" />
   
   <PropertyGroup>
       <!-- Because we may be building in a container, we should use an asset manifest file path
@@ -53,6 +55,7 @@
 
   <Target Name="PublishSdkAssetsAndChecksums"
           BeforeTargets="Publish"
+          DependsOnTargets="GenerateFullNuGetVersion"
           Condition=" '$(PublishSdkAssetsAndChecksumsToBlob)' == 'true' ">
 
     <!-- If the sdk version is stabilized, then we should double publish the binaries to suffixed file names.

--- a/src/CopyToLatest/CopyToLatest.csproj
+++ b/src/CopyToLatest/CopyToLatest.csproj
@@ -8,7 +8,7 @@
   <Import Project="targets\BranchInfo.props" />
   <Import Project="..\redist\targets\BuildCoreSdkTasks.targets" />
   <Import Project="..\redist\targets\GetRuntimeInformation.targets" />
-  <Import Project="..\redist\targets\SetBuildDefaults.targets" />
+  <Import Project="..\redist\targets\Versions.targets" />
   
   <Import Project="targets\FinishBuild.targets" />
 </Project>

--- a/src/CopyToLatest/targets/FinishBuild.targets
+++ b/src/CopyToLatest/targets/FinishBuild.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="FinalizeBuild"
           BeforeTargets="AfterBuild"
-          DependsOnTargets="GenerateFullNuGetVersion">
+          DependsOnTargets="GenerateFullNuGetVersion;GetCommitHash">
     <CopyBlobsToLatest FeedUrl="$(DotnetPublishSdkAssetsBlobFeedUrl)"
                        AccountKey="$(DotNetPublishSdkAssetsBlobFeedKey)"
                        NugetVersion="$(FullNugetVersion)"

--- a/src/CopyToLatest/targets/FinishBuild.targets
+++ b/src/CopyToLatest/targets/FinishBuild.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="FinalizeBuild"
-          BeforeTargets="AfterBuild">
+          BeforeTargets="AfterBuild"
+          DependsOnTargets="GenerateFullNuGetVersion">
     <CopyBlobsToLatest FeedUrl="$(DotnetPublishSdkAssetsBlobFeedUrl)"
                        AccountKey="$(DotNetPublishSdkAssetsBlobFeedKey)"
                        NugetVersion="$(FullNugetVersion)"

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -22,6 +22,7 @@
   <Import Project="targets\BuildCoreSdkTasks.targets" />
   <Import Project="targets\GetRuntimeInformation.targets" />
   <Import Project="targets\SetBuildDefaults.targets" />
+  <Import Project="targets\Versions.targets" />
   <Import Project="targets\Branding.targets" />
   <Import Project="targets\BundledTemplates.targets" />
   <Import Project="targets\BundledDotnetTools.targets" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -426,13 +426,6 @@
                       Overwrite="true" />
   </Target>
 
-  <Target Name="GenerateFullNuGetVersion">
-    <PropertyGroup>
-      <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</FullNugetVersion>
-      <FullNugetVersion Condition=" '$(VersionSuffixDateStamp)' != '' And '$(VersionSuffixBuildOfTheDay)' != '' ">$(FullNugetVersion).$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</FullNugetVersion>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="LayoutAppHostTemplate" DependsOnTargets="RunResolvePackageDependencies">
 
     <PropertyGroup>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -414,13 +414,7 @@
       ReplacementStrings="$(ReplacementString)" />
   </Target>
 
-  <Target Name="GenerateVersionFile" DependsOnTargets="SetupBundledComponents">
-    <Exec Command="git rev-parse HEAD"
-          ConsoleToMSBuild="true"
-          Condition=" '$(GitCommitHash)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
-    </Exec>
-
+  <Target Name="GenerateVersionFile" DependsOnTargets="SetupBundledComponents;GetCommitHash">
     <WriteLinesToFile File="$(SdkOutputDirectory).version"
                       Lines="$(GitCommitHash);$(Version);$(Rid)"
                       Overwrite="true" />

--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -5,4 +5,12 @@
       <FullNugetVersion Condition=" '$(VersionSuffixDateStamp)' != '' And '$(VersionSuffixBuildOfTheDay)' != '' ">$(FullNugetVersion).$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</FullNugetVersion>
     </PropertyGroup>
   </Target>
+
+  <Target Name="GetCommitHash">
+    <Exec Command="git rev-parse HEAD"
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitCommitHash)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
+    </Exec>
+  </Target>
 </Project>

--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -1,0 +1,8 @@
+<Project>
+  <Target Name="GenerateFullNuGetVersion">
+    <PropertyGroup>
+      <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</FullNugetVersion>
+      <FullNugetVersion Condition=" '$(VersionSuffixDateStamp)' != '' And '$(VersionSuffixBuildOfTheDay)' != '' ">$(FullNugetVersion).$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</FullNugetVersion>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
We still had build failures during the publishing step.

There were dependencies on FullNuGetVersion that could not be met. This PR moves some targets around to make it available in all the places it is needed.

I tested this one by running a full official build on it. We can do that now with the new versioning scheme. Plus, this was an unofficial branch without DARC channels on it.