### PR TITLE
Fix publishing folder and copy to latest

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -236,6 +236,7 @@ stages:
         - group: DotNet-DotNetCli-Storage
       steps:
         - script: eng/CopyToLatest.cmd
+                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                   /p:DotnetPublishSdkAssetsBlobFeedUrl=https://dotnetcli.blob.core.windows.net/dotnet/index.json
                   /p:DotNetPublishSdkAssetsBlobFeedKey=$(dotnetcli-storage-key)
                   /p:DotnetPublishChecksumsBlobFeedUrl=https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -15,8 +15,6 @@
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" Condition=" '$(PublishSdkAssetsAndChecksumsToBlob)' == 'true' " />
-
-  <Import Project="..\src\redist\targets\Versions.targets" />
   
   <PropertyGroup>
       <!-- Because we may be building in a container, we should use an asset manifest file path
@@ -55,8 +53,13 @@
 
   <Target Name="PublishSdkAssetsAndChecksums"
           BeforeTargets="Publish"
-          DependsOnTargets="GenerateFullNuGetVersion"
           Condition=" '$(PublishSdkAssetsAndChecksumsToBlob)' == 'true' ">
+
+    <ReadLinesFromFile File="$(ArtifactsTmpDir)FullNugetVersion.version">
+      <Output
+          TaskParameter="Lines"
+          PropertyName="FullNugetVersion"/>
+    </ReadLinesFromFile>
 
     <!-- If the sdk version is stabilized, then we should double publish the binaries to suffixed file names.
          To do this, create new copies of the blobs, replacing the SdkVersion string in the file name with the

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -414,9 +414,15 @@
       ReplacementStrings="$(ReplacementString)" />
   </Target>
 
-  <Target Name="GenerateVersionFile" DependsOnTargets="SetupBundledComponents;GetCommitHash">
+  <Target Name="GenerateVersionFile"
+          DependsOnTargets="SetupBundledComponents;GetCommitHash;GenerateFullNuGetVersion">
     <WriteLinesToFile File="$(SdkOutputDirectory).version"
                       Lines="$(GitCommitHash);$(Version);$(Rid)"
+                      Overwrite="true" />
+
+    <!-- This is a hack to make the full nuget version available during the publishing step -->
+    <WriteLinesToFile File="$(ArtifactsTmpDir)FullNugetVersion.version"
+                      Lines="$(FullNugetVersion)"
                       Overwrite="true" />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/toolset/issues/4023

Did a hack where we are writing the version to a file during build to be read during publish, as these are two separate builds by arcade and also passed the BuildNumberId so that the id is calculated properly during copy to latest.