### PR TITLE
Fix msi gg release/3.1.1xx

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Dotnet.Sdk.Intern
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkTests", "test\SdkTests\SdkTests.csproj", "{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "core-sdk-tasks.Tests", "test\core-sdk-tasks.Tests\core-sdk-tasks.Tests.csproj", "{658EF9BE-452C-4D31-AA24-B9E2235799A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}.Release|Any CPU.Build.0 = Release|Any CPU
+		{658EF9BE-452C-4D31-AA24-B9E2235799A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{658EF9BE-452C-4D31-AA24-B9E2235799A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{658EF9BE-452C-4D31-AA24-B9E2235799A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{658EF9BE-452C-4D31-AA24-B9E2235799A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,6 +72,7 @@ Global
 		{78E15EC1-7732-41E3-8591-934E9F583254} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+		{658EF9BE-452C-4D31-AA24-B9E2235799A8} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B526D2CE-EE2D-4AD4-93EF-1867D90FF1F5}

--- a/src/core-sdk-tasks/CalculateTemplateVersions.cs
+++ b/src/core-sdk-tasks/CalculateTemplateVersions.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class CalculateTemplateVersions : Task
+    {
+        [Required]
+        public string AspNetCorePackageVersionTemplate { get; set; }
+
+        [Required]
+        public string GitCommitCount { get; set; }
+
+        [Required]
+        public string VersionSuffix { get; set; }
+
+        [Output]
+        public string BundledTemplateMSIVersion { get; set; }
+
+        [Output]
+        public string BundledTemplateInstallPath { get; set; }
+
+        [Output]
+        public string BundledTemplateMajorMinorVersion { get; set; }
+
+        public override bool Execute()
+        {
+            var result = Calculate(AspNetCorePackageVersionTemplate, GitCommitCount, VersionSuffix);
+            BundledTemplateMSIVersion = result.BundledTemplateMsiVersion;
+            BundledTemplateInstallPath = result.BundledTemplateInstallPath;
+            BundledTemplateMajorMinorVersion = result.BundledTemplateMajorMinorVersion;
+
+            return true;
+        }
+
+        public static
+            (string BundledTemplateMsiVersion,
+            string BundledTemplateInstallPath,
+            string BundledTemplateMajorMinorVersion) Calculate(string aspNetCorePackageVersionTemplate,
+                string gitCommitCount, string versionSuffix)
+        {
+            (bool isStableVersion, string aspNetCoreVersionMajorMinorPatchVersion) =
+                GetAspNetCoreVersionMajorMinorPatchVersion(aspNetCorePackageVersionTemplate);
+
+            var bundledTemplateMsiVersion = $"{aspNetCoreVersionMajorMinorPatchVersion}.{gitCommitCount}";
+
+            string bundledTemplateInstallPath = isStableVersion
+                ? aspNetCoreVersionMajorMinorPatchVersion
+                : $"{aspNetCoreVersionMajorMinorPatchVersion}-{versionSuffix}";
+
+            var parsedAspNetCoreVersionMajorMinorPatchVersion =
+                System.Version.Parse(aspNetCoreVersionMajorMinorPatchVersion);
+            var bundledTemplateMajorMinorVersion =
+                $"{parsedAspNetCoreVersionMajorMinorPatchVersion.Major}.{parsedAspNetCoreVersionMajorMinorPatchVersion.Minor}";
+
+            return (
+                bundledTemplateMsiVersion,
+                bundledTemplateInstallPath,
+                bundledTemplateMajorMinorVersion);
+        }
+
+        private static (bool isStableVersion, string aspNetCoreVersionMajorMinorPatchVersion)
+            GetAspNetCoreVersionMajorMinorPatchVersion(string aspNetCorePackageVersionTemplate)
+        {
+            var indexOfAspNetCoreVersionPreReleaseSeparator = aspNetCorePackageVersionTemplate.IndexOf('-');
+            string aspNetCoreVersionMajorMinorPatchVersion;
+            if (indexOfAspNetCoreVersionPreReleaseSeparator != -1)
+            {
+                aspNetCoreVersionMajorMinorPatchVersion =
+                    aspNetCorePackageVersionTemplate.Substring(0, indexOfAspNetCoreVersionPreReleaseSeparator);
+            }
+            else
+            {
+                aspNetCoreVersionMajorMinorPatchVersion = aspNetCorePackageVersionTemplate;
+            }
+
+            return (indexOfAspNetCoreVersionPreReleaseSeparator == -1, aspNetCoreVersionMajorMinorPatchVersion);
+        }
+    }
+}

--- a/src/core-sdk-tasks/CalculateTemplateVersions.cs
+++ b/src/core-sdk-tasks/CalculateTemplateVersions.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Cli.Build
         [Output]
         public string BundledTemplateMajorMinorVersion { get; set; }
 
+        private const int _patchVersionResetOffset = 1;
+
         public override bool Execute()
         {
             var result = Calculate(AspNetCorePackageVersionTemplate, GitCommitCount, VersionSuffix);
@@ -47,8 +49,11 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var aspNetCoreTemplate = NuGetVersion.Parse(aspNetCorePackageVersionTemplate);
 
+            // due to historical bug https://github.com/dotnet/core-sdk/issues/6243
+            // we need to increase patch version by one in order to "reset" existing install ComponentId
+            // more in the above bug's detail
             var baseMajorMinorPatch = new NuGetVersion(aspNetCoreTemplate.Major, aspNetCoreTemplate.Minor,
-                aspNetCoreTemplate.Patch);
+                aspNetCoreTemplate.Patch + _patchVersionResetOffset);
 
             string bundledTemplateInstallPath = aspNetCoreTemplate.IsPrerelease
                 ? $"{baseMajorMinorPatch.Major}.{baseMajorMinorPatch.Minor}.{baseMajorMinorPatch.Patch}-{versionSuffix}"

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -19,6 +19,7 @@
              Properties="ArtifactsDir=$(ArtifactsDir)tasks\"/>
   </Target>
 
+  <UsingTask TaskName="CalculateTemplateVersions" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GetCurrentRuntimeInformation" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="DownloadFile" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="ExtractArchiveToDirectory" AssemblyFile="$(CoreSdkTaskDll)" />

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -1,47 +1,38 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="CalculateTemplatesVersions"
           DependsOnTargets="SetSdkVersionInfo">
-    <PropertyGroup>
-      <AspNetCore31VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor31Templates.IndexOf('-'))</AspNetCore31VersionPreReleaseSeparator>
-      <AspNetCore31VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor31Templates)</AspNetCore31VersionMajorMinorPatchVersion>
-      <AspNetCore31VersionMajorMinorPatchVersion Condition=" '$(AspNetCore31VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor31Templates.Substring(0, $(AspNetCore31VersionPreReleaseSeparator)))</AspNetCore31VersionMajorMinorPatchVersion>
-      <BundledTemplates31MSIVersion>$(AspNetCore31VersionMajorMinorPatchVersion).$(GitCommitCount)</BundledTemplates31MSIVersion>
-      <BundledTemplates31InstallPath>$(AspNetCore31VersionMajorMinorPatchVersion)</BundledTemplates31InstallPath>
-      <BundledTemplates31InstallPath Condition=" '$(AspNetCore31VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates31InstallPath)-$(VersionSuffix)</BundledTemplates31InstallPath>
-      <Templates31VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore31VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates31VersionPatchSeparatorIndex>
-      <Templates31VersionPatchSeparatorIndex>$(AspNetCore31VersionMajorMinorPatchVersion.IndexOf('.', $(Templates31VersionPatchSeparatorIndex)))</Templates31VersionPatchSeparatorIndex>
-      <BundledTemplates31MajorMinorVersion>$(AspNetCore31VersionMajorMinorPatchVersion.Substring(0, $(Templates31VersionPatchSeparatorIndex)))</BundledTemplates31MajorMinorVersion>
 
-      <AspNetCore30VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor30Templates.IndexOf('-'))</AspNetCore30VersionPreReleaseSeparator>
-      <AspNetCore30VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor30Templates)</AspNetCore30VersionMajorMinorPatchVersion>
-      <AspNetCore30VersionMajorMinorPatchVersion Condition=" '$(AspNetCore30VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor30Templates.Substring(0, $(AspNetCore30VersionPreReleaseSeparator)))</AspNetCore30VersionMajorMinorPatchVersion>
-      <BundledTemplates30MSIVersion>$(AspNetCore30VersionMajorMinorPatchVersion).$(GitCommitCount)</BundledTemplates30MSIVersion>
-      <BundledTemplates30InstallPath>$(AspNetCore30VersionMajorMinorPatchVersion)</BundledTemplates30InstallPath>
-      <BundledTemplates30InstallPath Condition=" '$(AspNetCore30VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates30InstallPath)-$(VersionSuffix)</BundledTemplates30InstallPath>
-      <Templates30VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore30VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates30VersionPatchSeparatorIndex>
-      <Templates30VersionPatchSeparatorIndex>$(AspNetCore30VersionMajorMinorPatchVersion.IndexOf('.', $(Templates30VersionPatchSeparatorIndex)))</Templates30VersionPatchSeparatorIndex>
-      <BundledTemplates30MajorMinorVersion>$(AspNetCore30VersionMajorMinorPatchVersion.Substring(0, $(Templates30VersionPatchSeparatorIndex)))</BundledTemplates30MajorMinorVersion>
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor31Templates)"
+                        GitCommitCount="$(GitCommitCount)"
+                        VersionSuffix="$(VersionSuffix)">
+      <Output TaskParameter="BundledTemplateMSIVersion" PropertyName="BundledTemplates31MSIVersion" />
+      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates31InstallPath" />
+      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates31MajorMinorVersion" />
+    </CalculateTemplateVersions>
 
-      <AspNetCore22VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor22Templates.IndexOf('-'))</AspNetCore22VersionPreReleaseSeparator>
-      <AspNetCore22VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor22Templates)</AspNetCore22VersionMajorMinorPatchVersion>
-      <AspNetCore22VersionMajorMinorPatchVersion Condition=" '$(AspNetCore22VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor22Templates.Substring(0, $(AspNetCore22VersionPreReleaseSeparator)))</AspNetCore22VersionMajorMinorPatchVersion>
-      <BundledTemplates22MSIVersion>$(AspNetCore22VersionMajorMinorPatchVersion).$(GitCommitCount)</BundledTemplates22MSIVersion>
-      <BundledTemplates22InstallPath>$(AspNetCore22VersionMajorMinorPatchVersion)</BundledTemplates22InstallPath>
-      <BundledTemplates22InstallPath Condition=" '$(AspNetCore22VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates22InstallPath)-$(VersionSuffix)</BundledTemplates22InstallPath>
-      <Templates22VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore22VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates22VersionPatchSeparatorIndex>
-      <Templates22VersionPatchSeparatorIndex>$(AspNetCore22VersionMajorMinorPatchVersion.IndexOf('.', $(Templates22VersionPatchSeparatorIndex)))</Templates22VersionPatchSeparatorIndex>
-      <BundledTemplates22MajorMinorVersion>$(AspNetCore22VersionMajorMinorPatchVersion.Substring(0, $(Templates22VersionPatchSeparatorIndex)))</BundledTemplates22MajorMinorVersion>
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor30Templates)"
+                        GitCommitCount="$(GitCommitCount)"
+                        VersionSuffix="$(VersionSuffix)">
+      <Output TaskParameter="BundledTemplateMSIVersion" PropertyName="BundledTemplates30MSIVersion" />
+      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates30InstallPath" />
+      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates30MajorMinorVersion" />
+    </CalculateTemplateVersions>
 
-      <AspNetCore21VersionPreReleaseSeparator>$(AspNetCorePackageVersionFor21Templates.IndexOf('-'))</AspNetCore21VersionPreReleaseSeparator>
-      <AspNetCore21VersionMajorMinorPatchVersion>$(AspNetCorePackageVersionFor21Templates)</AspNetCore21VersionMajorMinorPatchVersion>
-      <AspNetCore21VersionMajorMinorPatchVersion Condition=" '$(AspNetCore21VersionPreReleaseSeparator)' != -1 ">$(AspNetCorePackageVersionFor21Templates.Substring(0, $(AspNetCore21VersionPreReleaseSeparator)))</AspNetCore21VersionMajorMinorPatchVersion>
-      <BundledTemplates21MSIVersion>$(AspNetCore21VersionMajorMinorPatchVersion).$(GitCommitCount)</BundledTemplates21MSIVersion>
-      <BundledTemplates21InstallPath>$(AspNetCore21VersionMajorMinorPatchVersion)</BundledTemplates21InstallPath>
-      <BundledTemplates21InstallPath Condition=" '$(AspNetCore21VersionPreReleaseSeparator)' != -1 ">$(BundledTemplates21InstallPath)-$(VersionSuffix)</BundledTemplates21InstallPath>
-      <Templates21VersionPatchSeparatorIndex>$([MSBuild]::Add($(AspNetCore21VersionMajorMinorPatchVersion.IndexOf('.')), 1))</Templates21VersionPatchSeparatorIndex>
-      <Templates21VersionPatchSeparatorIndex>$(AspNetCore21VersionMajorMinorPatchVersion.IndexOf('.', $(Templates21VersionPatchSeparatorIndex)))</Templates21VersionPatchSeparatorIndex>
-      <BundledTemplates21MajorMinorVersion>$(AspNetCore21VersionMajorMinorPatchVersion.Substring(0, $(Templates21VersionPatchSeparatorIndex)))</BundledTemplates21MajorMinorVersion>
-    </PropertyGroup>
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor22Templates)"
+                        GitCommitCount="$(GitCommitCount)"
+                        VersionSuffix="$(VersionSuffix)">
+      <Output TaskParameter="BundledTemplateMSIVersion" PropertyName="BundledTemplates22MSIVersion" />
+      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates22InstallPath" />
+      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates22MajorMinorVersion" />
+    </CalculateTemplateVersions>
+
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor21Templates)"
+                        GitCommitCount="$(GitCommitCount)"
+                        VersionSuffix="$(VersionSuffix)">
+      <Output TaskParameter="BundledTemplateMSIVersion" PropertyName="BundledTemplates21MSIVersion" />
+      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates21InstallPath" />
+      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates21MajorMinorVersion" />
+    </CalculateTemplateVersions>
   </Target>
 
   <ItemGroup>

--- a/src/redist/targets/packaging/windows/clisdk/generatemsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatemsi.ps1
@@ -31,7 +31,7 @@ function RunHeat
     # use XSLT tranform to match the file path contains "AppHostTemplate\apphost.exe" and give it the same ID all the time.
 
     $heatOutput = .\heat.exe dir `"$inputDir`" -template fragment  `
-        -sreg -gg  `
+        -sreg -ag `
         -var var.DotnetSrc  `
         -cg InstallFiles  `
         -srd  `

--- a/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
@@ -25,7 +25,7 @@ function RunHeat
     Write-Information "Running heat.."
 
     $heatOutput = .\heat.exe dir `"$inputDir`" -template fragment  `
-        -sreg -gg  `
+        -sreg -ag `
         -var var.DotnetSrc  `
         -cg InstallFiles  `
         -srd  `

--- a/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using Xunit;
+using Microsoft.DotNet.Cli.Build;
+
+namespace EndToEnd
+{
+    public class CalculateTemplateVerionsTests
+    {
+        [Fact]
+        public void ItCanCalculateTemplateVersionsInStableBuilds()
+        {
+            var result = CalculateTemplateVersions.Calculate("3.1.0", "014885", "dev");
+            result.BundledTemplateInstallPath.Should().Be("3.1.0");
+            result.BundledTemplateMsiVersion.Should().Be("3.1.0.014885");
+            result.BundledTemplateMajorMinorVersion.Should().Be("3.1");
+        }
+
+        [Fact]
+        public void ItCanCalculateTemplateVersionsInNonStableBuilds()
+        {
+            var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6", "014885", "dev");
+            result.BundledTemplateInstallPath.Should().Be("5.0.0-dev");
+            result.BundledTemplateMsiVersion.Should().Be("5.0.0.014885");
+            result.BundledTemplateMajorMinorVersion.Should().Be("5.0");
+        }
+    }
+}

--- a/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -4,14 +4,15 @@ using Microsoft.DotNet.Cli.Build;
 
 namespace EndToEnd
 {
-    public class CalculateTemplateVerionsTests
+    public class CalculateTemplateVersionsTests
     {
         [Fact]
         public void ItCanCalculateTemplateVersionsInStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("3.1.0", "014885", "dev");
-            result.BundledTemplateInstallPath.Should().Be("3.1.0");
-            result.BundledTemplateMsiVersion.Should().Be("3.1.0.014885");
+            result.BundledTemplateInstallPath.Should().Be("3.1.1",
+                "the patch is 1 higher than aspnetTemplateVersion due to  https://github.com/dotnet/core-sdk/issues/6243");
+            result.BundledTemplateMsiVersion.Should().Be("3.1.1.014885");
             result.BundledTemplateMajorMinorVersion.Should().Be("3.1");
         }
 
@@ -19,8 +20,8 @@ namespace EndToEnd
         public void ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6", "014885", "dev");
-            result.BundledTemplateInstallPath.Should().Be("5.0.0-dev");
-            result.BundledTemplateMsiVersion.Should().Be("5.0.0.014885");
+            result.BundledTemplateInstallPath.Should().Be("5.0.1-dev");
+            result.BundledTemplateMsiVersion.Should().Be("5.0.1.014885");
             result.BundledTemplateMajorMinorVersion.Should().Be("5.0");
         }
     }

--- a/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -7,22 +7,43 @@ namespace EndToEnd
     public class CalculateTemplateVersionsTests
     {
         [Fact]
-        public void ItCanCalculateTemplateVersionsInStableBuilds()
+        public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("3.1.0", "014885", "dev");
-            result.BundledTemplateInstallPath.Should().Be("3.1.1",
-                "the patch is 1 higher than aspnetTemplateVersion due to  https://github.com/dotnet/core-sdk/issues/6243");
-            result.BundledTemplateMsiVersion.Should().Be("3.1.1.014885");
-            result.BundledTemplateMajorMinorVersion.Should().Be("3.1");
+
+            result.Should()
+                .Be(("3.1.1.014885", "3.1.1", "3.1"),
+                    "the patch is 1 higher than aspnetTemplateVersion " +
+                    "due to https://github.com/dotnet/core-sdk/issues/6243");
         }
 
         [Fact]
-        public void ItCanCalculateTemplateVersionsInNonStableBuilds()
+        public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
+        {
+            var result = CalculateTemplateVersions.Calculate("3.0.0-alpha.1.20071.6", "014885", "dev");
+
+            result.Should()
+                .Be(("3.0.1.014885", "3.0.1-dev", "3.0"));
+        }
+
+        [Fact]
+        public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInStableBuilds()
+        {
+            var result = CalculateTemplateVersions.Calculate("5.1.0", "014885", "dev");
+
+            result.Should()
+                .Be(("5.1.0.014885", "5.1.0", "5.1"),
+                     "the patch align with AspNetCoreTemplateMajorVersion again, " +
+                     "since there is no non-deterministic existing ComponentId under Major version 5.");
+        }
+
+        [Fact]
+        public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6", "014885", "dev");
-            result.BundledTemplateInstallPath.Should().Be("5.0.1-dev");
-            result.BundledTemplateMsiVersion.Should().Be("5.0.1.014885");
-            result.BundledTemplateMajorMinorVersion.Should().Be("5.0");
+
+            result.Should()
+                .Be(("5.0.0.014885", "5.0.0-dev", "5.0"));
         }
     }
 }

--- a/test/core-sdk-tasks.Tests/core-sdk-tasks.Tests.csproj
+++ b/test/core-sdk-tasks.Tests/core-sdk-tasks.Tests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<PropertyGroup>
+    <TargetFrameworks>$(CoreSdkTargetFramework);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(CoreSdkTargetFramework)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\core-sdk-tasks\core-sdk-tasks.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #6243

**Description**

A new guid is generated every time for componentID even it is the same KeyPath. As a result, the system cannot correctly ref count the files. (it should be able to ref count the files even different msis install to the same exact location).

This change fixed the guid generation, made it deterministic according to the KeyPath. At the same time, in order to “reset” the incorrect existing componentID, we forced bump all templates version number, so it is a new install location.

**Customer Impact**

Error for installation ref counting. One instance is 3.0/2.1 template is missing in Create ASP.NET Core Web Application dialog after uninstall the 16.5 preview 2 when 16.4 is installed.

**Regression?**

no

**Risk**

low.
