### PR TITLE
Updated test template versions for 2.1, 3.0, and 3.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
-    <MicrosoftDotNetTestProjectTemplates31PackageVersion>1.0.2-beta4.19570.1</MicrosoftDotNetTestProjectTemplates31PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates31PackageVersion>1.0.2-beta4.20105.2</MicrosoftDotNetTestProjectTemplates31PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
@@ -96,19 +96,18 @@
     <NUnit3Templates30PackageVersion>1.6.5</NUnit3Templates30PackageVersion>
     <MicrosoftDotNetCommonItemTemplates30PackageVersion>2.0.0-preview8.19373.1</MicrosoftDotNetCommonItemTemplates30PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplates30PackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.19354.2</MicrosoftDotNetTestProjectTemplates30PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.20105.2</MicrosoftDotNetTestProjectTemplates30PackageVersion>
     <AspNetCorePackageVersionFor30Templates>3.0.1</AspNetCorePackageVersionFor30Templates>
     <!-- 2.2 Template versions -->
     <NUnit3Templates22PackageVersion>1.6.0</NUnit3Templates22PackageVersion>
     <MicrosoftDotNetCommonItemTemplates22PackageVersion>1.0.2-beta4</MicrosoftDotNetCommonItemTemplates22PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates22PackageVersion>$(MicrosoftDotNetCommonItemTemplates22PackageVersion)</MicrosoftDotNetCommonProjectTemplates22PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates22PackageVersion>1.0.2-beta4.19155.2</MicrosoftDotNetTestProjectTemplates22PackageVersion>
     <AspNetCorePackageVersionFor22Templates>2.2.8</AspNetCorePackageVersionFor22Templates>
     <!-- 2.1 Template versions -->
     <NUnit3Templates21PackageVersion>1.5.3</NUnit3Templates21PackageVersion>
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4-20181009-2100240</MicrosoftDotNetTestProjectTemplates21PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.20105.2</MicrosoftDotNetTestProjectTemplates21PackageVersion>
     <AspNetCorePackageVersionFor21Templates>2.1.14</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,11 +98,6 @@
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplates30PackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
     <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.20105.2</MicrosoftDotNetTestProjectTemplates30PackageVersion>
     <AspNetCorePackageVersionFor30Templates>3.0.1</AspNetCorePackageVersionFor30Templates>
-    <!-- 2.2 Template versions -->
-    <NUnit3Templates22PackageVersion>1.6.0</NUnit3Templates22PackageVersion>
-    <MicrosoftDotNetCommonItemTemplates22PackageVersion>1.0.2-beta4</MicrosoftDotNetCommonItemTemplates22PackageVersion>
-    <MicrosoftDotNetCommonProjectTemplates22PackageVersion>$(MicrosoftDotNetCommonItemTemplates22PackageVersion)</MicrosoftDotNetCommonProjectTemplates22PackageVersion>
-    <AspNetCorePackageVersionFor22Templates>2.2.8</AspNetCorePackageVersionFor22Templates>
     <!-- 2.1 Template versions -->
     <NUnit3Templates21PackageVersion>1.5.3</NUnit3Templates21PackageVersion>
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>

--- a/src/redist/targets/Branding.targets
+++ b/src/redist/targets/Branding.targets
@@ -15,7 +15,6 @@
       <SharedFrameworkNugetName>$(SharedFrameworkName)</SharedFrameworkNugetName>
       <BundledTemplates31BrandName>Microsoft .NET Core 3.1 Templates $(CliBrandingVersion)</BundledTemplates31BrandName>
       <BundledTemplates30BrandName>Microsoft .NET Core 3.0 Templates $(CliBrandingVersion)</BundledTemplates30BrandName>
-      <BundledTemplates22BrandName>Microsoft .NET Core 2.2 Templates $(CliBrandingVersion)</BundledTemplates22BrandName>
       <BundledTemplates21BrandName>Microsoft .NET Core 2.1 Templates $(CliBrandingVersion)</BundledTemplates21BrandName>
     </PropertyGroup>
   </Target>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -18,14 +18,6 @@
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates30MajorMinorVersion" />
     </CalculateTemplateVersions>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor22Templates)"
-                        GitCommitCount="$(GitCommitCount)"
-                        VersionSuffix="$(VersionSuffix)">
-      <Output TaskParameter="BundledTemplateMSIVersion" PropertyName="BundledTemplates22MSIVersion" />
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates22InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates22MajorMinorVersion" />
-    </CalculateTemplateVersions>
-
     <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor21Templates)"
                         GitCommitCount="$(GitCommitCount)"
                         VersionSuffix="$(VersionSuffix)">
@@ -58,15 +50,6 @@
     <Bundled30Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates30PackageVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <Bundled22Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates22PackageVersion)" />
-    <Bundled22Templates Include="Microsoft.DotNet.Common.ProjectTemplates.2.2" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates22PackageVersion)" />
-    <Bundled22Templates Include="Microsoft.DotNet.Test.ProjectTemplates.2.2" PackageVersion="$(MicrosoftDotNetTestProjectTemplates22PackageVersion)" />
-    <Bundled22Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor22Templates)" />
-    <Bundled22Templates Include="Microsoft.DotNet.Web.ProjectTemplates.2.2" PackageVersion="$(AspNetCorePackageVersionFor22Templates)" />
-    <Bundled22Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2" PackageVersion="$(AspNetCorePackageVersionFor22Templates)" />
-    <Bundled22Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates22PackageVersion)" />
-  </ItemGroup>
-  <ItemGroup>
     <Bundled21Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates21PackageVersion)" />
     <Bundled21Templates Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates21PackageVersion)" />
     <Bundled21Templates Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates21PackageVersion)" />
@@ -91,13 +74,6 @@
     </Bundled30Templates>
   </ItemGroup>
   <ItemGroup>
-    <Bundled22Templates Update="@(Bundled22Templates)">
-      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
-      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled22Templates>
-  </ItemGroup>
-  <ItemGroup>
     <Bundled21Templates Update="@(Bundled21Templates)">
       <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
       <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
@@ -109,32 +85,27 @@
     <!-- PackageDownload items must not have duplicate itemspecs, handle packages with multiple versions specially below -->
 
     <PackageDownload Include="@(Bundled21Templates)" Exclude="@(PackageDownload)" />
-    <PackageDownload Include="@(Bundled22Templates)" Exclude="@(PackageDownload)" />
     <PackageDownload Include="@(Bundled30Templates)" Exclude="@(PackageDownload)" />
     <PackageDownload Include="@(Bundled31Templates)" Exclude="@(PackageDownload)" />
 
     <PackageDownload Update="Microsoft.DotNet.Common.ItemTemplates"
                      Version="[$(MicrosoftDotNetCommonItemTemplates21PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates22PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates30PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates31PackageVersion)];
                               " />
 
     <PackageDownload Update="Microsoft.DotNet.Web.Spa.ProjectTemplates"
                      Version="[$(AspNetCorePackageVersionFor21Templates)];
-                              [$(AspNetCorePackageVersionFor22Templates)];
                               " />
 
     <PackageDownload Update="Microsoft.DotNet.Web.ItemTemplates"
                      Version="[$(AspNetCorePackageVersionFor21Templates)];
-                              [$(AspNetCorePackageVersionFor22Templates)];
                               [$(AspNetCorePackageVersionFor30Templates)];
                               [$(AspNetCorePackageVersionFor31Templates)];
                               " />
 
     <PackageDownload Update="NUnit3.DotNetNew.Template"
                      Version="[$(NUnit3Templates21PackageVersion)];
-                              [$(NUnit3Templates22PackageVersion)];
                               [$(NUnit3Templates30PackageVersion)];
                               [$(NUnit3Templates31PackageVersion)];
                               " />
@@ -151,7 +122,7 @@
   </ItemGroup>
 
   <Target Name="LayoutTemplates"
-        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor22MSI;LayoutTemplatesFor21MSI" />
+        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor21MSI" />
 
   <Target Name="LayoutTemplatesForSDK"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions">
@@ -175,13 +146,6 @@
           Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
     <Copy SourceFiles="%(Bundled30Templates.RestoredNupkgPath)"
           DestinationFolder="$(Templates30LayoutPath)templates/$(BundledTemplates30InstallPath)"/>
-  </Target>
-
-  <Target Name="LayoutTemplatesFor22MSI"
-          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
-    <Copy SourceFiles="%(Bundled22Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates22LayoutPath)templates/$(BundledTemplates22InstallPath)"/>
   </Target>
 
   <Target Name="LayoutTemplatesFor21MSI"

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -4,7 +4,6 @@
     <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet-internal\</SdkInternalLayoutPath>
     <Templates31LayoutPath>$(BaseOutputPath)$(Configuration)\templates-3.1\</Templates31LayoutPath>
     <Templates30LayoutPath>$(BaseOutputPath)$(Configuration)\templates-3.0\</Templates30LayoutPath>
-    <Templates22LayoutPath>$(BaseOutputPath)$(Configuration)\templates-2.2\</Templates22LayoutPath>
     <Templates21LayoutPath>$(BaseOutputPath)$(Configuration)\templates-2.1\</Templates21LayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>
   </PropertyGroup>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -41,7 +41,6 @@
       <SdkDependencyKeyName>Dotnet_CLI</SdkDependencyKeyName>
       <Templates31MSIInstallerFile>$(ArtifactsShippingPackagesDir)dotnet-31templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates31MSIInstallerFile>
       <Templates30MSIInstallerFile>$(ArtifactsShippingPackagesDir)dotnet-30templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates30MSIInstallerFile>
-      <Templates22MSIInstallerFile>$(ArtifactsShippingPackagesDir)dotnet-22templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates22MSIInstallerFile>
       <Templates21MSIInstallerFile>$(ArtifactsShippingPackagesDir)dotnet-21templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates21MSIInstallerFile>
       <SdkPlaceholderMSIInstallerFile>$(ArtifactsShippingPackagesDir)dotnet-sdkplaceholder-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</SdkPlaceholderMSIInstallerFile>
       <SdkPlaceholderDependencyKeyName>NetCore_SdkPlaceholder</SdkPlaceholderDependencyKeyName>
@@ -60,7 +59,7 @@
           DependsOnTargets="GenerateLayout;SetupWixProperties;GetCoreSdkGitCommitInfo">
     <!-- Consumed By Publish -->
     <ItemGroup>
-      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(Templates31MSIInstallerFile);$(Templates30MSIInstallerFile);$(Templates22MSIInstallerFile);$(Templates21MSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile);$(SdkPlaceholderMSIInstallerFile)" />
+      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(Templates31MSIInstallerFile);$(Templates30MSIInstallerFile);$(Templates21MSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile);$(SdkPlaceholderMSIInstallerFile)" />
     </ItemGroup>
 
     <GenerateMsiVersion CommitCount="$(GitCommitCount)"
@@ -83,11 +82,6 @@
     <GenerateGuidFromName Name="$(Templates30MSIInstallerFile)">
       <Output TaskParameter="OutputGuid"
           PropertyName="Templates30InstallerUpgradeCode" />
-    </GenerateGuidFromName>
-
-    <GenerateGuidFromName Name="$(Templates22MSIInstallerFile)">
-      <Output TaskParameter="OutputGuid"
-          PropertyName="Templates22InstallerUpgradeCode" />
     </GenerateGuidFromName>
 
     <GenerateGuidFromName Name="$(Templates21MSIInstallerFile)">
@@ -214,14 +208,6 @@
         <UpgradeCode>$(Templates30InstallerUpgradeCode)</UpgradeCode>
         <DependencyKeyName>NetCore_Templates_3.0</DependencyKeyName>
       </TemplatesMsiComponent>
-      <TemplatesMsiComponent Include="NetCore22TemplatesMsi">
-        <LayoutPath>$(Templates22LayoutPath.TrimEnd('\'))</LayoutPath>
-        <MSIInstallerFile>$(Templates22MSIInstallerFile)</MSIInstallerFile>
-        <BrandName>$(BundledTemplates22BrandName)</BrandName>
-        <MsiVersion>$(BundledTemplates22MsiVersion)</MsiVersion>
-        <UpgradeCode>$(Templates22InstallerUpgradeCode)</UpgradeCode>
-        <DependencyKeyName>NetCore_Templates_2.2</DependencyKeyName>
-      </TemplatesMsiComponent>
       <TemplatesMsiComponent Include="NetCore21TemplatesMsi">
         <LayoutPath>$(Templates21LayoutPath.TrimEnd('\'))</LayoutPath>
         <MSIInstallerFile>$(Templates21MSIInstallerFile)</MSIInstallerFile>
@@ -344,11 +330,6 @@
         <MSIInstallerFile>$(Templates30MSIInstallerFile)</MSIInstallerFile>
         <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates30MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
         <MajorMinorVersion>$(BundledTemplates30MajorMinorVersion)</MajorMinorVersion>
-      </TemplatesNupkgComponent>
-      <TemplatesNupkgComponent Include="NetCore22TemplatesNupkg">
-        <MSIInstallerFile>$(Templates22MSIInstallerFile)</MSIInstallerFile>
-        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates22MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
-        <MajorMinorVersion>$(BundledTemplates22MajorMinorVersion)</MajorMinorVersion>
       </TemplatesNupkgComponent>
       <TemplatesNupkgComponent Include="NetCore21TemplatesNupkg">
         <MSIInstallerFile>$(Templates21MSIInstallerFile)</MSIInstallerFile>

--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -177,7 +177,6 @@
     <ItemGroup>
       <TemplatesMsiFilesToSign Include="$(Templates31MSIInstallerFile)" />
       <TemplatesMsiFilesToSign Include="$(Templates30MSIInstallerFile)" />
-      <TemplatesMsiFilesToSign Include="$(Templates22MSIInstallerFile)" />
       <TemplatesMsiFilesToSign Include="$(Templates21MSIInstallerFile)" />
       
       <TemplatesMsiFileSignInfo Include="@(TemplatesMsiFilesToSign->'%(Filename)%(Extension)')">


### PR DESCRIPTION
Updating versions of templates for 2.1, 3.0 and 3.1 to the latest test platform and mstest. 

Removing 2.2 version because it reached end of life and we don't produce that template anymore.


@nguerrera is this the correct branch to target?
