### PR TITLE
Simplify eng\publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -14,8 +14,6 @@
     <PublishBinariesAndBadge Condition=" '$(PublishBinariesAndBadge)' == '' ">true</PublishBinariesAndBadge>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" Condition=" '$(PublishSdkAssetsAndChecksumsToBlob)' == 'true' " />
-  
   <PropertyGroup>
       <!-- Because we may be building in a container, we should use an asset manifest file path
              that exists in the container. Disambiguate the manifests via available properties.
@@ -111,9 +109,6 @@
       </ChecksumsWithSuffixToPushToBlobFeed>
     </ItemGroup>
 
-    <MakeDir Directories="$(DotnetTempWorkingDirectory)"/>
-    <MakeDir Directories="$(ChecksumTempWorkingDirectory)"/>
-
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(SdkAssetsToPushToBlobFeed);@(SdkAssetsWithSuffixToPushToBlobFeed)"
       ManifestBuildData="Location=$(SdkAssetsFeedUrl)"
@@ -122,8 +117,7 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(DotNetAssetManifestFilePath)"
-      PublishFlatContainer="true"
-      AssetsTemporaryDirectory="$(DotnetTempWorkingDirectory)" />
+      PublishFlatContainer="true" />
 
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ChecksumsToPushToBlobFeed);@(ChecksumsWithSuffixToPushToBlobFeed)"
@@ -133,23 +127,6 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(ChecksumsAssetManifestFilePath)"
-      PublishFlatContainer="true"
-      AssetsTemporaryDirectory="$(ChecksumTempWorkingDirectory)" />
-
-    <Copy
-      SourceFiles="$(DotNetAssetManifestFilePath)"
-      DestinationFolder="$(DotnetTempWorkingDirectory)\$(AssetManifestFileName)" />
-
-    <Copy
-      SourceFiles="$(ChecksumsAssetManifestFilePath)"
-      DestinationFolder="$(ChecksumTempWorkingDirectory)\$(ChecksumsAssetManifestFileName)" />
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(DotnetTempWorkingDirectory)/$(AssetManifestFileName)"
-      Importance="high" />
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(ChecksumTempWorkingDirectory)/$(ChecksumsAssetManifestFileName)"
-      Importance="high" />
+      PublishFlatContainer="true" />
   </Target>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,8 +122,7 @@
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
-    <BuildTasksFeedToolVersion>2.2.0-beta.19072.10</BuildTasksFeedToolVersion>
-    <VersionToolsVersion>$(BuildTasksFeedToolVersion)</VersionToolsVersion>
+    <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
     <MicrosoftNETTestSdkVersion>15.8.0</MicrosoftNETTestSdkVersion>
   </PropertyGroup>


### PR DESCRIPTION
- With newer versions of Microsoft.DotNet.Build.Tasks.Feed you don't need to pass a temporary path to the manifest. I.e., we can remove `AssetsTemporaryDirectory` and associated code.
- The import in eng\publishing.props also isn't needed once this PR is merged: https://github.com/dotnet/arcade/pull/4626

Tested this change here:
- https://dnceng.visualstudio.com/internal/_build/results?buildId=506210
- https://dnceng.visualstudio.com/internal/_build/results?buildId=530063

/cc @livarcocc 