### PR TITLE
Add 5.0 common project templates to Bundle.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,7 +97,7 @@
     <MicrosoftDotNetWpfProjectTemplates31PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates31PackageVersion>
     <NUnit3Templates31PackageVersion>$(NUnit3DotNetNewTemplatePackageVersion)</NUnit3Templates31PackageVersion>
     <MicrosoftDotNetCommonItemTemplates31PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonItemTemplates31PackageVersion>
-    <MicrosoftDotNetCommonProjectTemplates31PackageVersion>3.1.0-preview1.19475.1</MicrosoftDotNetCommonProjectTemplates31PackageVersion>
+    <MicrosoftDotNetCommonProjectTemplates31PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonProjectTemplates31PackageVersion>
     <AspNetCorePackageVersionFor31Templates>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</AspNetCorePackageVersionFor31Templates>
     <!-- 3.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>4.8.0-rc2.19462.10</MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <Bundled31Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates31PackageVersion)" />
-    <Bundled31Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)" />
+    <Bundled31Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates31PackageVersion)" />

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -36,9 +36,7 @@ namespace EndToEnd.Tests
             var runCommand = new RunCommand()
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput()
-                // Templates are still at 3.1 and will not run on 5.0, revert to commented out assertion when 5.0 templates land
-                //.Should().Pass().And.HaveStdOutContaining("Hello World!");
-                .Should().Fail().And.HaveStdErrContaining("https://aka.ms/dotnet-core-applaunch");
+                .Should().Pass().And.HaveStdOutContaining("Hello World!");
 
             var binDirectory = new DirectoryInfo(projectDirectory).Sub("bin");
             binDirectory.Should().HaveFilesMatching("*.dll", SearchOption.AllDirectories);
@@ -80,10 +78,7 @@ namespace EndToEnd.Tests
             var runCommand = new RunCommand()
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput()
-                // Templates are still at 3.1 and will not run on 5.0, revert to commented out assertion when 5.0 templates land
-                //.Should().Pass().And.HaveStdOutContaining("Hello World!");
-                .Should().Fail().And.HaveStdErrContaining("https://aka.ms/dotnet-core-applaunch");
-
+                .Should().Pass().And.HaveStdOutContaining("Hello World!");
         }
 
         [Theory]


### PR DESCRIPTION
This adds the 5.0 project templates for console and class library to the bundle.

Package Version will need to be updated with the correct version after associated dotnet/templating PR is merged: https://github.com/dotnet/templating/pull/2293

Issue: https://github.com/dotnet/templating/issues/2245
