### PR TITLE
Bump self-contained default for 3.0.x and 2.1.x

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,9 @@
     <add key="darc-pub-dotnet-corefx-0f7f38c" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-0f7f38c4/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-aspnetcore-c3acdca-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-c3acdcac-2/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <!-- 3.0.3 runtime pack/apphost packs are needed for tests, and not on nuget.org yet or other feeds below. Darc cannot see that due to nonstandard way these are pulled in to a non-3.0 branch -->
+    <add key="darc-pub-dotnet-core-setup-c03f2fe" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-c03f2fe6/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-aspnetcore-bd1e14b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-bd1e14b7/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -14,11 +14,11 @@
       <_NETStandardLibraryPackageVersion>$(NETStandardLibraryRefPackageVersion)</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
-      <_NETCoreApp30RuntimePackVersion>3.0.2</_NETCoreApp30RuntimePackVersion>
+      <_NETCoreApp30RuntimePackVersion>3.0.3</_NETCoreApp30RuntimePackVersion>
       <_NETCoreApp30TargetingPackVersion>3.0.0</_NETCoreApp30TargetingPackVersion>
-      <_WindowsDesktop30RuntimePackVersion>3.0.2</_WindowsDesktop30RuntimePackVersion>
+      <_WindowsDesktop30RuntimePackVersion>3.0.3</_WindowsDesktop30RuntimePackVersion>
       <_WindowsDesktop30TargetingPackVersion>3.0.0</_WindowsDesktop30TargetingPackVersion>
-      <_AspNet30RuntimePackVersion>3.0.2</_AspNet30RuntimePackVersion>
+      <_AspNet30RuntimePackVersion>3.0.3</_AspNet30RuntimePackVersion>
       <_AspNet30TargetingPackVersion>3.0.1</_AspNet30TargetingPackVersion>
 
       <!-- Use only major and minor in target framework version -->
@@ -92,7 +92,7 @@
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.0"
-                               LatestVersion="2.1.15" />
+                               LatestVersion="2.1.16" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.2"
                                DefaultVersion="2.2.0"
@@ -100,11 +100,11 @@
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.1"
-                               LatestVersion="2.1.15"/>
+                               LatestVersion="2.1.16"/>
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
                                TargetFrameworkVersion="2.1"
                                DefaultVersion="2.1.1"
-                               LatestVersion="2.1.15"/>
+                               LatestVersion="2.1.16"/>
 
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
                                TargetFrameworkVersion="2.2"


### PR DESCRIPTION
* Bump self-contained default for 3.0.x and 2.1.x

* Add 3.0.3 feeds for tests
