### PR TITLE
Update minimum supported OSX version to 10.13

### DIFF
--- a/src/redist/targets/packaging/osx/clisdk/Distribution-Template
+++ b/src/redist/targets/packaging/osx/clisdk/Distribution-Template
@@ -7,7 +7,7 @@
     <conclusion file="conclusion.html" mime-type="text/html" />
     <volume-check>
         <allowed-os-versions>
-            <os-version min="10.12" />
+            <os-version min="10.13" />
         </allowed-os-versions>
     </volume-check>
     <choices-outline>


### PR DESCRIPTION
.NET Core 3.1 (or later) does not support OSX versions lower than 10.13: https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md

This PR updates the minimum version to 10.13 - see issue: https://github.com/dotnet/core-sdk/issues/6742
