### PR TITLE
Disable Partial Crossgen and Crossgen More Binaries

### DIFF
--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 return $"{GetReadyToRun()} {GetPlatformAssemblyPaths()} {GetDiasymReaderPath()} {GetCreateSymbols()}";
             }
 
-            return $"{GetReadyToRun()} {GetInPath()} {GetOutPath()} {GetPlatformAssemblyPaths()} {GetJitPath()}";
+            return $"{GetReadyToRun()} {GetMissingDependenciesOk()} {GetInPath()} {GetOutPath()} {GetPlatformAssemblyPaths()} {GetJitPath()}";
         }
 
         private string GetCreateSymbols()
@@ -200,6 +200,11 @@ namespace Microsoft.DotNet.Build.Tasks
         private string GetJitPath()
         {
             return $"-JITPath {JITPath}";
+        }
+
+        private string GetMissingDependenciesOk()
+        {
+            return "-MissingDependenciesOK";
         }
 
         protected override void LogToolCommand(string message)

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -13,6 +13,13 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     public sealed class Crossgen : ToolTask
     {
+        public Crossgen()
+        {
+            // Disable partial NGEN to avoid excess JIT-compilation.
+            // The intention is to pre-compile as much as possible.
+            EnvironmentVariables = new string[] { "COMPlus_PartialNGen=0" };
+        }
+
         [Required]
         public string SourceAssembly { get;set; }
 

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -48,6 +48,11 @@
       <!-- Add back the .NET Core assemblies in the Sdks folder -->
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk\tools\netcoreapp*\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\NuGet.Build.Tasks.Pack\CoreCLR\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\netcoreapp*\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\ILLink.Tasks\tools\netcoreapp*\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Publish\tools\netcoreapp*\**\*" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(SdkOutputDirectory)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />


### PR DESCRIPTION
### Summary ###

This PR is an effort to reduce foreground JIT time by increasing pre-compilation.  There are two components to this change which I describe below.  Beyond the description is performance data to show the cost and benefit of each of the components of this change.

**The combination of these two changes results in much less unexpected jitting, but does increase the size on disk of the SDK.  The performance numbers below represent the differences between the current state and the changes described here.  I believe that the reduction in wall-clock and jitting time provided by both changes (the full column) makes taking the PR in its entirety worthwhile, even with the increase in size on disk.  Taking just the first part of the change reduces the impact on size, but also significantly reduces the impact on wall-clock time.**

### Description of the Changes in this PR ###

1. Disable partial NGEN: Partial NGEN is an optimization that allows the producer of a binary to specify which methods should be pre-compiled based on profile data.  This is useful when size on disk and/or virtual memory are at a premium.  Many of the binaries in the SDK set the partial NGEN bit because they also ship with Visual Studio, but don't have the profile data to support core-sdk scenarios, which results in lots of unexpected jitting.  Thus, disabling partial NGEN results in a larger disk footprint and a significant reduction in jitting.
2. Crossgen more assemblies: There are a number of assemblies in the SDK layout that are not currently crossgen'd, resulting in unexpected jitting.  These assemblies were explicitly excluded because crossgen was previously failing with an error.  To fix the error, this change specifies -MissingDependenciesOK as an argument to crossgen.  It's OK if dependencies are missing because they are not needed for R2R as there is no cross-module inlining (at least without version bubbles).

### Column Descriptions ###

**Current** = No Changes
**NoPartial** = Disable Partial NGEN
**Full** = Disable Partial NGEN + Crossgen More Assemblies

### Size on Disk ###

| Configuration          | Current MB | NoPartial MB | Full MB | Diff NoPartial/Current | Diff Full/Current |
|------------------------|------------|--------------|---------|------------------------|-------------------|
| Windows (Zip)          | 153.89     | 164.24       | 168.59  | +10.35 (6.73%)         | +14.7 (9.55%)     |
| Windows (Uncompressed) | 424.71     | 439.38       | 451.73  | +14.67 (3.45%)         | +27.02 (6.36%)    |
| Linux (Tarball)        | 109.21     | 115.65       | 124.14  | +6.44 (5.90%)          | +14.93 (13.67%)   |
| Linux (Uncompressed)   | 322.95     | 338.04       | 356.54  | +15.09 (4.67%)         | +33.59 (10.40%)   |

Note: I don't have OSX numbers as my Mac laptop is stuck at work, but I expect them to be similar to Linux.

### Execution Time ###

| Configuration (Windows)                         | Current MS | NoPartial MS | Full MS | Diff NoPartial/Current | Diff Full/Current  |
|-------------------------------------------------|------------|--------------|---------|------------------------|--------------------|
| dotnet new razor - wall clock                   | 5755.79    | 5300.32      | 4377.89 | -455.47 (-7.91%)       | -1377.9 (-23.94%)  |
| dotnet new razor - foreground JIT               | 1160.8     | 759.5        | 750.5   | -401.3 (-34.57%)       | -410.3 (-35.35%)   |
| dotnet run (razor) - first run - wall clock     | 7473.15    | 6971.39      | 6117.32 | -501.76 (-6.7%)        | -1355.83 (-18.14%) |
| dotnet run (razor) - first run - foreground JIT | 3592.2     | 3050.4       | 1825.2  | -541.8 (-15.08%)       | -1767 (-49.19%)    |
| dotnet run (razor) - next run - wall clock      | 6345.78    | 5542.62      | 4792.94 | -803.16 (-12.66%)      | -1552.84 (-24.47%) |
| dotnet run (razor) - next run - foreground JIT  | 1468.3     | 1226.8       | 1010.1  | -241.5 (-16.45%)       | -458.2 (-31.2%)    |

