### PR TITLE
Revert "Update web templates for preview2"

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -57,9 +57,8 @@
     <Bundled50Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
-    <!-- Pin the aspnetcore templates until https://github.com/dotnet/aspnetcore/pull/19860 is resolved. -->
-    <Bundled50Templates Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" PackageVersion="5.0.0-preview.2.318.dev" />
-    <Bundled50Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" PackageVersion="5.0.0-preview.2.318.dev" />
+    <Bundled50Templates Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
+    <Bundled50Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
     <Bundled50Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates50PackageVersion)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Reverts dotnet/core-sdk#6860

We just noticed that the web templates are broken because of this. The manual update of the web templates causes PackageReferences to not resolve as versions are hardcoded inside the templates. The dev package submission then required that exact dev version of the other dependencies.

We need to revisit this for preview3, I'm out of options for the web templates for preview until we have a VS 16.5 image to build on for aspnetcore.

_Will discuss this in today's Tactics meeting._