### PR TITLE
Add 5.0-preview2 download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,19 @@ With development builds, internal NuGet feeds are necessary for some scenarios (
 </configuration>
 ```
 
-| Platform | Master<br>(5.0.x&nbsp;Runtime) | 5.0.100 Preview 1<br>(5.0 Runtime) | Release/3.1.3XX<br>(3.1.x Runtime) | Release/3.1.2XX<br>(3.1.x Runtime) | Release/3.1.1XX<br>(3.1.x Runtime) | Release/3.0.1xx<br>(3.0.x Runtime) |
-| :--------- | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
-| **Windows x64** | [![][win-x64-badge-master]][win-x64-version-master]<br>[Installer][win-x64-installer-master] - [Checksum][win-x64-installer-checksum-master]<br>[zip][win-x64-zip-master] - [Checksum][win-x64-zip-checksum-master] | [![][win-x64-badge-5.0.1XX-preview1]][win-x64-version-5.0.1XX-preview1]<br>[Installer][win-x64-installer-5.0.1XX-preview1] - [Checksum][win-x64-installer-checksum-5.0.1XX-preview1]<br>[zip][win-x64-zip-5.0.1XX-preview1] - [Checksum][win-x64-zip-checksum-5.0.1XX-preview1] | [![][win-x64-badge-3.1.3XX]][win-x64-version-3.1.3XX]<br>[Installer][win-x64-installer-3.1.3XX] - [Checksum][win-x64-installer-checksum-3.1.3XX]<br>[zip][win-x64-zip-3.1.3XX] - [Checksum][win-x64-zip-checksum-3.1.3XX] | [![][win-x64-badge-3.1.2XX]][win-x64-version-3.1.2XX]<br>[Installer][win-x64-installer-3.1.2XX] - [Checksum][win-x64-installer-checksum-3.1.2XX]<br>[zip][win-x64-zip-3.1.2XX] - [Checksum][win-x64-zip-checksum-3.1.2XX] | [![][win-x64-badge-3.1.1XX]][win-x64-version-3.1.1XX]<br>[Installer][win-x64-installer-3.1.1XX] - [Checksum][win-x64-installer-checksum-3.1.1XX]<br>[zip][win-x64-zip-3.1.1XX] - [Checksum][win-x64-zip-checksum-3.1.1XX] | [![][win-x64-badge-3.0.1XX]][win-x64-version-3.0.1XX]<br>[Installer][win-x64-installer-3.0.1XX] - [Checksum][win-x64-installer-checksum-3.0.1XX]<br>[zip][win-x64-zip-3.0.1XX] - [Checksum][win-x64-zip-checksum-3.0.1XX] |
-| **Windows x86** | [![][win-x86-badge-master]][win-x86-version-master]<br>[Installer][win-x86-installer-master] - [Checksum][win-x86-installer-checksum-master]<br>[zip][win-x86-zip-master] - [Checksum][win-x86-zip-checksum-master] | [![][win-x86-badge-5.0.1XX-preview1]][win-x86-version-5.0.1XX-preview1]<br>[Installer][win-x86-installer-5.0.1XX-preview1] - [Checksum][win-x86-installer-checksum-5.0.1XX-preview1]<br>[zip][win-x86-zip-5.0.1XX-preview1] - [Checksum][win-x86-zip-checksum-5.0.1XX-preview1] | [![][win-x86-badge-3.1.3XX]][win-x86-version-3.1.3XX]<br>[Installer][win-x86-installer-3.1.3XX] - [Checksum][win-x86-installer-checksum-3.1.3XX]<br>[zip][win-x86-zip-3.1.3XX] - [Checksum][win-x86-zip-checksum-3.1.3XX] | [![][win-x86-badge-3.1.2XX]][win-x86-version-3.1.2XX]<br>[Installer][win-x86-installer-3.1.2XX] - [Checksum][win-x86-installer-checksum-3.1.2XX]<br>[zip][win-x86-zip-3.1.2XX] - [Checksum][win-x86-zip-checksum-3.1.2XX] | [![][win-x86-badge-3.1.1XX]][win-x86-version-3.1.1XX]<br>[Installer][win-x86-installer-3.1.1XX] - [Checksum][win-x86-installer-checksum-3.1.1XX]<br>[zip][win-x86-zip-3.1.1XX] - [Checksum][win-x86-zip-checksum-3.1.1XX] | [![][win-x86-badge-3.0.1XX]][win-x86-version-3.0.1XX]<br>[Installer][win-x86-installer-3.0.1XX] - [Checksum][win-x86-installer-checksum-3.0.1XX]<br>[zip][win-x86-zip-3.0.1XX] - [Checksum][win-x86-zip-checksum-3.0.1XX] |
-| **macOS** | [![][osx-badge-master]][osx-version-master]<br>[Installer][osx-installer-master] - [Checksum][osx-installer-checksum-master]<br>[tar.gz][osx-targz-master] - [Checksum][osx-targz-checksum-master] | [![][osx-badge-5.0.1XX-preview1]][osx-version-5.0.1XX-preview1]<br>[Installer][osx-installer-5.0.1XX-preview1] - [Checksum][osx-installer-checksum-5.0.1XX-preview1]<br>[tar.gz][osx-targz-5.0.1XX-preview1] - [Checksum][osx-targz-checksum-5.0.1XX-preview1] | [![][osx-badge-3.1.3XX]][osx-version-3.1.3XX]<br>[Installer][osx-installer-3.1.3XX] - [Checksum][osx-installer-checksum-3.1.3XX]<br>[tar.gz][osx-targz-3.1.3XX] - [Checksum][osx-targz-checksum-3.1.3XX] | [![][osx-badge-3.1.2XX]][osx-version-3.1.2XX]<br>[Installer][osx-installer-3.1.2XX] - [Checksum][osx-installer-checksum-3.1.2XX]<br>[tar.gz][osx-targz-3.1.2XX] - [Checksum][osx-targz-checksum-3.1.2XX] | [![][osx-badge-3.1.1XX]][osx-version-3.1.1XX]<br>[Installer][osx-installer-3.1.1XX] - [Checksum][osx-installer-checksum-3.1.1XX]<br>[tar.gz][osx-targz-3.1.1XX] - [Checksum][osx-targz-checksum-3.1.1XX] | [![][osx-badge-3.0.1XX]][osx-version-3.0.1XX]<br>[Installer][osx-installer-3.0.1XX] - [Checksum][osx-installer-checksum-3.0.1XX]<br>[tar.gz][osx-targz-3.0.1XX] - [Checksum][osx-targz-checksum-3.0.1XX] |
-| **Linux x64** | [![][linux-badge-master]][linux-version-master]<br>[DEB Installer][linux-DEB-installer-master] - [Checksum][linux-DEB-installer-checksum-master]<br>[RPM Installer][linux-RPM-installer-master] - [Checksum][linux-RPM-installer-checksum-master]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-master] - [Checksum][linux-targz-checksum-master] | [![][linux-badge-5.0.1XX-preview1]][linux-version-5.0.1XX-preview1]<br>[DEB Installer][linux-DEB-installer-5.0.1XX-preview1] - [Checksum][linux-DEB-installer-checksum-5.0.1XX-preview1]<br>[RPM Installer][linux-RPM-installer-5.0.1XX-preview1] - [Checksum][linux-RPM-installer-checksum-5.0.1XX-preview1]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-5.0.1XX-preview1] - [Checksum][linux-targz-checksum-5.0.1XX-preview1] | [![][linux-badge-3.1.3XX]][linux-version-3.1.3XX]<br>[DEB Installer][linux-DEB-installer-3.1.3XX] - [Checksum][linux-DEB-installer-checksum-3.1.3XX]<br>[RPM Installer][linux-RPM-installer-3.1.3XX] - [Checksum][linux-RPM-installer-checksum-3.1.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.3XX] - [Checksum][linux-targz-checksum-3.1.3XX] | [![][linux-badge-3.1.2XX]][linux-version-3.1.2XX]<br>[DEB Installer][linux-DEB-installer-3.1.2XX] - [Checksum][linux-DEB-installer-checksum-3.1.2XX]<br>[RPM Installer][linux-RPM-installer-3.1.2XX] - [Checksum][linux-RPM-installer-checksum-3.1.2XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.2XX] - [Checksum][linux-targz-checksum-3.1.2XX] | [![][linux-badge-3.1.1XX]][linux-version-3.1.1XX]<br>[DEB Installer][linux-DEB-installer-3.1.1XX] - [Checksum][linux-DEB-installer-checksum-3.1.1XX]<br>[RPM Installer][linux-RPM-installer-3.1.1XX] - [Checksum][linux-RPM-installer-checksum-3.1.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.1XX] - [Checksum][linux-targz-checksum-3.1.1XX] | [![][linux-badge-3.0.1XX]][linux-version-3.0.1XX]<br>[DEB Installer][linux-DEB-installer-3.0.1XX] - [Checksum][linux-DEB-installer-checksum-3.0.1XX]<br>[RPM Installer][linux-RPM-installer-3.0.1XX] - [Checksum][linux-RPM-installer-checksum-3.0.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.0.1XX] - [Checksum][linux-targz-checksum-3.0.1XX] |
-| **Linux arm** | [![][linux-arm-badge-master]][linux-arm-version-master]<br>[tar.gz][linux-arm-targz-master] - [Checksum][linux-arm-targz-checksum-master] | [![][linux-arm-badge-5.0.1XX-preview1]][linux-arm-version-5.0.1XX-preview1]<br>[tar.gz][linux-arm-targz-5.0.1XX-preview1] - [Checksum][linux-arm-targz-checksum-5.0.1XX-preview1] | [![][linux-arm-badge-3.1.3XX]][linux-arm-version-3.1.3XX]<br>[tar.gz][linux-arm-targz-3.1.3XX] - [Checksum][linux-arm-targz-checksum-3.1.3XX] | [![][linux-arm-badge-3.1.2XX]][linux-arm-version-3.1.2XX]<br>[tar.gz][linux-arm-targz-3.1.2XX] - [Checksum][linux-arm-targz-checksum-3.1.2XX] | [![][linux-arm-badge-3.1.1XX]][linux-arm-version-3.1.1XX]<br>[tar.gz][linux-arm-targz-3.1.1XX] - [Checksum][linux-arm-targz-checksum-3.1.1XX] | [![][linux-arm-badge-3.0.1XX]][linux-arm-version-3.0.1XX]<br>[tar.gz][linux-arm-targz-3.0.1XX] - [Checksum][linux-arm-targz-checksum-3.0.1XX] |
-| **Linux arm64** | [![][linux-arm64-badge-master]][linux-arm64-version-master]<br>[tar.gz][linux-arm64-targz-master] - [Checksum][linux-arm64-targz-checksum-master] | [![][linux-arm64-badge-5.0.1XX-preview1]][linux-arm64-version-5.0.1XX-preview1]<br>[tar.gz][linux-arm64-targz-5.0.1XX-preview1] - [Checksum][linux-arm64-targz-checksum-5.0.1XX-preview1] | [![][linux-arm64-badge-3.1.3XX]][linux-arm64-version-3.1.3XX]<br>[tar.gz][linux-arm64-targz-3.1.3XX] - [Checksum][linux-arm64-targz-checksum-3.1.3XX] | [![][linux-arm64-badge-3.1.2XX]][linux-arm64-version-3.1.2XX]<br>[tar.gz][linux-arm64-targz-3.1.2XX] - [Checksum][linux-arm64-targz-checksum-3.1.2XX] | [![][linux-arm64-badge-3.1.1XX]][linux-arm64-version-3.1.1XX]<br>[tar.gz][linux-arm64-targz-3.1.1XX] - [Checksum][linux-arm64-targz-checksum-3.1.1XX] | [![][linux-arm64-badge-3.0.1XX]][linux-arm64-version-3.0.1XX]<br>[tar.gz][linux-arm64-targz-3.0.1XX] - [Checksum][linux-arm64-targz-checksum-3.0.1XX] |
-| **RHEL 6** | [![][rhel-6-badge-master]][rhel-6-version-master]<br>[tar.gz][rhel-6-targz-master] - [Checksum][rhel-6-targz-checksum-master] | [![][rhel-6-badge-5.0.1XX-preview1]][rhel-6-version-5.0.1XX-preview1]<br>[tar.gz][rhel-6-targz-5.0.1XX-preview1] - [Checksum][rhel-6-targz-checksum-5.0.1XX-preview1] | [![][rhel-6-badge-3.1.3XX]][rhel-6-version-3.1.3XX]<br>[tar.gz][rhel-6-targz-3.1.3XX] - [Checksum][rhel-6-targz-checksum-3.1.3XX] | [![][rhel-6-badge-3.1.2XX]][rhel-6-version-3.1.2XX]<br>[tar.gz][rhel-6-targz-3.1.2XX] - [Checksum][rhel-6-targz-checksum-3.1.2XX] | [![][rhel-6-badge-3.1.1XX]][rhel-6-version-3.1.1XX]<br>[tar.gz][rhel-6-targz-3.1.1XX] - [Checksum][rhel-6-targz-checksum-3.1.1XX] | [![][rhel-6-badge-3.0.1XX]][rhel-6-version-3.0.1XX]<br>[tar.gz][rhel-6-targz-3.0.1XX] - [Checksum][rhel-6-targz-checksum-3.0.1XX] |
-| **Linux-musl** | [![][linux-musl-badge-master]][linux-musl-version-master]<br>[tar.gz][linux-musl-targz-master] - [Checksum][linux-musl-targz-checksum-master] | [![][linux-musl-badge-5.0.1XX-preview1]][linux-musl-version-5.0.1XX-preview1]<br>[tar.gz][linux-musl-targz-5.0.1XX-preview1] - [Checksum][linux-musl-targz-checksum-5.0.1XX-preview1] | [![][linux-musl-badge-3.1.3XX]][linux-musl-version-3.1.3XX]<br>[tar.gz][linux-musl-targz-3.1.3XX] - [Checksum][linux-musl-targz-checksum-3.1.3XX] | [![][linux-musl-badge-3.1.2XX]][linux-musl-version-3.1.2XX]<br>[tar.gz][linux-musl-targz-3.1.2XX] - [Checksum][linux-musl-targz-checksum-3.1.2XX] | [![][linux-musl-badge-3.1.1XX]][linux-musl-version-3.1.1XX]<br>[tar.gz][linux-musl-targz-3.1.1XX] - [Checksum][linux-musl-targz-checksum-3.1.1XX] | [![][linux-musl-badge-3.0.1XX]][linux-musl-version-3.0.1XX]<br>[tar.gz][linux-musl-targz-3.0.1XX] - [Checksum][linux-musl-targz-checksum-3.0.1XX] |
-| **Windows arm** | [![][win-arm-badge-master]][win-arm-version-master]<br>[zip][win-arm-zip-master] - [Checksum][win-arm-zip-checksum-master] | **N/A** | [![][win-arm-badge-3.1.3XX]][win-arm-version-3.1.3XX]<br>[zip][win-arm-zip-3.1.3XX] - [Checksum][win-arm-zip-checksum-3.1.3XX] | [![][win-arm-badge-3.1.2XX]][win-arm-version-3.1.2XX]<br>[zip][win-arm-zip-3.1.2XX] - [Checksum][win-arm-zip-checksum-3.1.2XX] | [![][win-arm-badge-3.1.1XX]][win-arm-version-3.1.1XX]<br>[zip][win-arm-zip-3.1.1XX] - [Checksum][win-arm-zip-checksum-3.1.1XX] | [![][win-arm-badge-3.0.1XX]][win-arm-version-3.0.1XX]<br>[zip][win-arm-zip-3.0.1XX] - [Checksum][win-arm-zip-checksum-3.0.1XX] |
-| **Windows arm64** | [![][win-arm-64-badge-master]][win-arm-64-version-master]<br>[zip][win-arm-64-zip-master] | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** |
-| **FreeBSD x64** | [![][freebsd-x64-badge-master]][freebsd-x64-version-master]<br>[tar.gz][freebsd-x64-zip-master] - [Checksum][freebsd-x64-zip-checksum-master]  | **N/A** | [![][freebsd-x64-badge-3.1.3XX]][freebsd-x64-version-3.1.3XX]<br>[tar.gz][freebsd-x64-zip-3.1.3XX] - [Checksum][freebsd-x64-zip-checksum-3.1.3XX]  | [![][freebsd-x64-badge-3.1.2XX]][freebsd-x64-version-3.1.2XX]<br>[tar.gz][freebsd-x64-zip-3.1.2XX] - [Checksum][freebsd-x64-zip-checksum-3.1.2XX]  | [![][freebsd-x64-badge-3.1.1XX]][freebsd-x64-version-3.1.1XX]<br>[tar.gz][freebsd-x64-zip-3.1.1XX] - [Checksum][freebsd-x64-zip-checksum-3.1.1XX]  | [![][freebsd-x64-badge-3.0.1XX]][freebsd-x64-version-3.0.1XX]<br>[tar.gz][freebsd-x64-zip-3.0.1XX] - [Checksum][freebsd-x64-zip-checksum-3.0.1XX]  |
-| **Constituent Repo Shas** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | [Git SHAs][sdk-shas-2.2.1XX] |
+| Platform | Master<br>(5.0.x&nbsp;Runtime) | 5.0.100 Preview 2<br>(5.0 Runtime) | 5.0.100 Preview 1<br>(5.0 Runtime) | Release/3.1.3XX<br>(3.1.x Runtime) | Release/3.1.2XX<br>(3.1.x Runtime) | Release/3.1.1XX<br>(3.1.x Runtime) | Release/3.0.1xx<br>(3.0.x Runtime) |
+| :--------- | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
+| **Windows x64** | [![][win-x64-badge-master]][win-x64-version-master]<br>[Installer][win-x64-installer-master] - [Checksum][win-x64-installer-checksum-master]<br>[zip][win-x64-zip-master] - [Checksum][win-x64-zip-checksum-master] | [![][win-x64-badge-5.0.1XX-preview2]][win-x64-version-5.0.1XX-preview2]<br>[Installer][win-x64-installer-5.0.1XX-preview2] - [Checksum][win-x64-installer-checksum-5.0.1XX-preview2]<br>[zip][win-x64-zip-5.0.1XX-preview2] - [Checksum][win-x64-zip-checksum-5.0.1XX-preview2] | [![][win-x64-badge-5.0.1XX-preview1]][win-x64-version-5.0.1XX-preview1]<br>[Installer][win-x64-installer-5.0.1XX-preview1] - [Checksum][win-x64-installer-checksum-5.0.1XX-preview1]<br>[zip][win-x64-zip-5.0.1XX-preview1] - [Checksum][win-x64-zip-checksum-5.0.1XX-preview1] | [![][win-x64-badge-3.1.3XX]][win-x64-version-3.1.3XX]<br>[Installer][win-x64-installer-3.1.3XX] - [Checksum][win-x64-installer-checksum-3.1.3XX]<br>[zip][win-x64-zip-3.1.3XX] - [Checksum][win-x64-zip-checksum-3.1.3XX] | [![][win-x64-badge-3.1.2XX]][win-x64-version-3.1.2XX]<br>[Installer][win-x64-installer-3.1.2XX] - [Checksum][win-x64-installer-checksum-3.1.2XX]<br>[zip][win-x64-zip-3.1.2XX] - [Checksum][win-x64-zip-checksum-3.1.2XX] | [![][win-x64-badge-3.1.1XX]][win-x64-version-3.1.1XX]<br>[Installer][win-x64-installer-3.1.1XX] - [Checksum][win-x64-installer-checksum-3.1.1XX]<br>[zip][win-x64-zip-3.1.1XX] - [Checksum][win-x64-zip-checksum-3.1.1XX] | [![][win-x64-badge-3.0.1XX]][win-x64-version-3.0.1XX]<br>[Installer][win-x64-installer-3.0.1XX] - [Checksum][win-x64-installer-checksum-3.0.1XX]<br>[zip][win-x64-zip-3.0.1XX] - [Checksum][win-x64-zip-checksum-3.0.1XX] |
+| **Windows x86** | [![][win-x86-badge-master]][win-x86-version-master]<br>[Installer][win-x86-installer-master] - [Checksum][win-x86-installer-checksum-master]<br>[zip][win-x86-zip-master] - [Checksum][win-x86-zip-checksum-master] | [![][win-x86-badge-5.0.1XX-preview2]][win-x86-version-5.0.1XX-preview2]<br>[Installer][win-x86-installer-5.0.1XX-preview2] - [Checksum][win-x86-installer-checksum-5.0.1XX-preview2]<br>[zip][win-x86-zip-5.0.1XX-preview2] - [Checksum][win-x86-zip-checksum-5.0.1XX-preview2] | [![][win-x86-badge-5.0.1XX-preview1]][win-x86-version-5.0.1XX-preview1]<br>[Installer][win-x86-installer-5.0.1XX-preview1] - [Checksum][win-x86-installer-checksum-5.0.1XX-preview1]<br>[zip][win-x86-zip-5.0.1XX-preview1] - [Checksum][win-x86-zip-checksum-5.0.1XX-preview1] | [![][win-x86-badge-3.1.3XX]][win-x86-version-3.1.3XX]<br>[Installer][win-x86-installer-3.1.3XX] - [Checksum][win-x86-installer-checksum-3.1.3XX]<br>[zip][win-x86-zip-3.1.3XX] - [Checksum][win-x86-zip-checksum-3.1.3XX] | [![][win-x86-badge-3.1.2XX]][win-x86-version-3.1.2XX]<br>[Installer][win-x86-installer-3.1.2XX] - [Checksum][win-x86-installer-checksum-3.1.2XX]<br>[zip][win-x86-zip-3.1.2XX] - [Checksum][win-x86-zip-checksum-3.1.2XX] | [![][win-x86-badge-3.1.1XX]][win-x86-version-3.1.1XX]<br>[Installer][win-x86-installer-3.1.1XX] - [Checksum][win-x86-installer-checksum-3.1.1XX]<br>[zip][win-x86-zip-3.1.1XX] - [Checksum][win-x86-zip-checksum-3.1.1XX] | [![][win-x86-badge-3.0.1XX]][win-x86-version-3.0.1XX]<br>[Installer][win-x86-installer-3.0.1XX] - [Checksum][win-x86-installer-checksum-3.0.1XX]<br>[zip][win-x86-zip-3.0.1XX] - [Checksum][win-x86-zip-checksum-3.0.1XX] |
+| **macOS** | [![][osx-badge-master]][osx-version-master]<br>[Installer][osx-installer-master] - [Checksum][osx-installer-checksum-master]<br>[tar.gz][osx-targz-master] - [Checksum][osx-targz-checksum-master] | [![][osx-badge-5.0.1XX-preview2]][osx-version-5.0.1XX-preview2]<br>[Installer][osx-installer-5.0.1XX-preview2] - [Checksum][osx-installer-checksum-5.0.1XX-preview2]<br>[tar.gz][osx-targz-5.0.1XX-preview2] - [Checksum][osx-targz-checksum-5.0.1XX-preview2] | [![][osx-badge-5.0.1XX-preview1]][osx-version-5.0.1XX-preview1]<br>[Installer][osx-installer-5.0.1XX-preview1] - [Checksum][osx-installer-checksum-5.0.1XX-preview1]<br>[tar.gz][osx-targz-5.0.1XX-preview1] - [Checksum][osx-targz-checksum-5.0.1XX-preview1] | [![][osx-badge-3.1.3XX]][osx-version-3.1.3XX]<br>[Installer][osx-installer-3.1.3XX] - [Checksum][osx-installer-checksum-3.1.3XX]<br>[tar.gz][osx-targz-3.1.3XX] - [Checksum][osx-targz-checksum-3.1.3XX] | [![][osx-badge-3.1.2XX]][osx-version-3.1.2XX]<br>[Installer][osx-installer-3.1.2XX] - [Checksum][osx-installer-checksum-3.1.2XX]<br>[tar.gz][osx-targz-3.1.2XX] - [Checksum][osx-targz-checksum-3.1.2XX] | [![][osx-badge-3.1.1XX]][osx-version-3.1.1XX]<br>[Installer][osx-installer-3.1.1XX] - [Checksum][osx-installer-checksum-3.1.1XX]<br>[tar.gz][osx-targz-3.1.1XX] - [Checksum][osx-targz-checksum-3.1.1XX] | [![][osx-badge-3.0.1XX]][osx-version-3.0.1XX]<br>[Installer][osx-installer-3.0.1XX] - [Checksum][osx-installer-checksum-3.0.1XX]<br>[tar.gz][osx-targz-3.0.1XX] - [Checksum][osx-targz-checksum-3.0.1XX] |
+| **Linux x64** | [![][linux-badge-master]][linux-version-master]<br>[DEB Installer][linux-DEB-installer-master] - [Checksum][linux-DEB-installer-checksum-master]<br>[RPM Installer][linux-RPM-installer-master] - [Checksum][linux-RPM-installer-checksum-master]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-master] - [Checksum][linux-targz-checksum-master] | [![][linux-badge-5.0.1XX-preview2]][linux-version-5.0.1XX-preview2]<br>[DEB Installer][linux-DEB-installer-5.0.1XX-preview2] - [Checksum][linux-DEB-installer-checksum-5.0.1XX-preview2]<br>[RPM Installer][linux-RPM-installer-5.0.1XX-preview2] - [Checksum][linux-RPM-installer-checksum-5.0.1XX-preview2]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-5.0.1XX-preview2] - [Checksum][linux-targz-checksum-5.0.1XX-preview2] | [![][linux-badge-5.0.1XX-preview1]][linux-version-5.0.1XX-preview1]<br>[DEB Installer][linux-DEB-installer-5.0.1XX-preview1] - [Checksum][linux-DEB-installer-checksum-5.0.1XX-preview1]<br>[RPM Installer][linux-RPM-installer-5.0.1XX-preview1] - [Checksum][linux-RPM-installer-checksum-5.0.1XX-preview1]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-5.0.1XX-preview1] - [Checksum][linux-targz-checksum-5.0.1XX-preview1] | [![][linux-badge-3.1.3XX]][linux-version-3.1.3XX]<br>[DEB Installer][linux-DEB-installer-3.1.3XX] - [Checksum][linux-DEB-installer-checksum-3.1.3XX]<br>[RPM Installer][linux-RPM-installer-3.1.3XX] - [Checksum][linux-RPM-installer-checksum-3.1.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.3XX] - [Checksum][linux-targz-checksum-3.1.3XX] | [![][linux-badge-3.1.2XX]][linux-version-3.1.2XX]<br>[DEB Installer][linux-DEB-installer-3.1.2XX] - [Checksum][linux-DEB-installer-checksum-3.1.2XX]<br>[RPM Installer][linux-RPM-installer-3.1.2XX] - [Checksum][linux-RPM-installer-checksum-3.1.2XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.2XX] - [Checksum][linux-targz-checksum-3.1.2XX] | [![][linux-badge-3.1.1XX]][linux-version-3.1.1XX]<br>[DEB Installer][linux-DEB-installer-3.1.1XX] - [Checksum][linux-DEB-installer-checksum-3.1.1XX]<br>[RPM Installer][linux-RPM-installer-3.1.1XX] - [Checksum][linux-RPM-installer-checksum-3.1.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.1XX] - [Checksum][linux-targz-checksum-3.1.1XX] | [![][linux-badge-3.0.1XX]][linux-version-3.0.1XX]<br>[DEB Installer][linux-DEB-installer-3.0.1XX] - [Checksum][linux-DEB-installer-checksum-3.0.1XX]<br>[RPM Installer][linux-RPM-installer-3.0.1XX] - [Checksum][linux-RPM-installer-checksum-3.0.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.0.1XX] - [Checksum][linux-targz-checksum-3.0.1XX] |
+| **Linux arm** | [![][linux-arm-badge-master]][linux-arm-version-master]<br>[tar.gz][linux-arm-targz-master] - [Checksum][linux-arm-targz-checksum-master] | [![][linux-arm-badge-5.0.1XX-preview2]][linux-arm-version-5.0.1XX-preview2]<br>[tar.gz][linux-arm-targz-5.0.1XX-preview2] - [Checksum][linux-arm-targz-checksum-5.0.1XX-preview2] | [![][linux-arm-badge-5.0.1XX-preview1]][linux-arm-version-5.0.1XX-preview1]<br>[tar.gz][linux-arm-targz-5.0.1XX-preview1] - [Checksum][linux-arm-targz-checksum-5.0.1XX-preview1] | [![][linux-arm-badge-3.1.3XX]][linux-arm-version-3.1.3XX]<br>[tar.gz][linux-arm-targz-3.1.3XX] - [Checksum][linux-arm-targz-checksum-3.1.3XX] | [![][linux-arm-badge-3.1.2XX]][linux-arm-version-3.1.2XX]<br>[tar.gz][linux-arm-targz-3.1.2XX] - [Checksum][linux-arm-targz-checksum-3.1.2XX] | [![][linux-arm-badge-3.1.1XX]][linux-arm-version-3.1.1XX]<br>[tar.gz][linux-arm-targz-3.1.1XX] - [Checksum][linux-arm-targz-checksum-3.1.1XX] | [![][linux-arm-badge-3.0.1XX]][linux-arm-version-3.0.1XX]<br>[tar.gz][linux-arm-targz-3.0.1XX] - [Checksum][linux-arm-targz-checksum-3.0.1XX] |
+| **Linux arm64** | [![][linux-arm64-badge-master]][linux-arm64-version-master]<br>[tar.gz][linux-arm64-targz-master] - [Checksum][linux-arm64-targz-checksum-master] | [![][linux-arm64-badge-5.0.1XX-preview2]][linux-arm64-version-5.0.1XX-preview2]<br>[tar.gz][linux-arm64-targz-5.0.1XX-preview2] - [Checksum][linux-arm64-targz-checksum-5.0.1XX-preview2] | [![][linux-arm64-badge-5.0.1XX-preview1]][linux-arm64-version-5.0.1XX-preview1]<br>[tar.gz][linux-arm64-targz-5.0.1XX-preview1] - [Checksum][linux-arm64-targz-checksum-5.0.1XX-preview1] | [![][linux-arm64-badge-3.1.3XX]][linux-arm64-version-3.1.3XX]<br>[tar.gz][linux-arm64-targz-3.1.3XX] - [Checksum][linux-arm64-targz-checksum-3.1.3XX] | [![][linux-arm64-badge-3.1.2XX]][linux-arm64-version-3.1.2XX]<br>[tar.gz][linux-arm64-targz-3.1.2XX] - [Checksum][linux-arm64-targz-checksum-3.1.2XX] | [![][linux-arm64-badge-3.1.1XX]][linux-arm64-version-3.1.1XX]<br>[tar.gz][linux-arm64-targz-3.1.1XX] - [Checksum][linux-arm64-targz-checksum-3.1.1XX] | [![][linux-arm64-badge-3.0.1XX]][linux-arm64-version-3.0.1XX]<br>[tar.gz][linux-arm64-targz-3.0.1XX] - [Checksum][linux-arm64-targz-checksum-3.0.1XX] |
+| **RHEL 6** | [![][rhel-6-badge-master]][rhel-6-version-master]<br>[tar.gz][rhel-6-targz-master] - [Checksum][rhel-6-targz-checksum-master] | [![][rhel-6-badge-5.0.1XX-preview2]][rhel-6-version-5.0.1XX-preview2]<br>[tar.gz][rhel-6-targz-5.0.1XX-preview2] - [Checksum][rhel-6-targz-checksum-5.0.1XX-preview2] | [![][rhel-6-badge-5.0.1XX-preview1]][rhel-6-version-5.0.1XX-preview1]<br>[tar.gz][rhel-6-targz-5.0.1XX-preview1] - [Checksum][rhel-6-targz-checksum-5.0.1XX-preview1] | [![][rhel-6-badge-3.1.3XX]][rhel-6-version-3.1.3XX]<br>[tar.gz][rhel-6-targz-3.1.3XX] - [Checksum][rhel-6-targz-checksum-3.1.3XX] | [![][rhel-6-badge-3.1.2XX]][rhel-6-version-3.1.2XX]<br>[tar.gz][rhel-6-targz-3.1.2XX] - [Checksum][rhel-6-targz-checksum-3.1.2XX] | [![][rhel-6-badge-3.1.1XX]][rhel-6-version-3.1.1XX]<br>[tar.gz][rhel-6-targz-3.1.1XX] - [Checksum][rhel-6-targz-checksum-3.1.1XX] | [![][rhel-6-badge-3.0.1XX]][rhel-6-version-3.0.1XX]<br>[tar.gz][rhel-6-targz-3.0.1XX] - [Checksum][rhel-6-targz-checksum-3.0.1XX] |
+| **Linux-musl** | [![][linux-musl-badge-master]][linux-musl-version-master]<br>[tar.gz][linux-musl-targz-master] - [Checksum][linux-musl-targz-checksum-master] | [![][linux-musl-badge-5.0.1XX-preview2]][linux-musl-version-5.0.1XX-preview2]<br>[tar.gz][linux-musl-targz-5.0.1XX-preview2] - [Checksum][linux-musl-targz-checksum-5.0.1XX-preview2] | [![][linux-musl-badge-5.0.1XX-preview1]][linux-musl-version-5.0.1XX-preview1]<br>[tar.gz][linux-musl-targz-5.0.1XX-preview1] - [Checksum][linux-musl-targz-checksum-5.0.1XX-preview1] | [![][linux-musl-badge-3.1.3XX]][linux-musl-version-3.1.3XX]<br>[tar.gz][linux-musl-targz-3.1.3XX] - [Checksum][linux-musl-targz-checksum-3.1.3XX] | [![][linux-musl-badge-3.1.2XX]][linux-musl-version-3.1.2XX]<br>[tar.gz][linux-musl-targz-3.1.2XX] - [Checksum][linux-musl-targz-checksum-3.1.2XX] | [![][linux-musl-badge-3.1.1XX]][linux-musl-version-3.1.1XX]<br>[tar.gz][linux-musl-targz-3.1.1XX] - [Checksum][linux-musl-targz-checksum-3.1.1XX] | [![][linux-musl-badge-3.0.1XX]][linux-musl-version-3.0.1XX]<br>[tar.gz][linux-musl-targz-3.0.1XX] - [Checksum][linux-musl-targz-checksum-3.0.1XX] |
+| **Windows arm** | [![][win-arm-badge-master]][win-arm-version-master]<br>[zip][win-arm-zip-master] - [Checksum][win-arm-zip-checksum-master] | **N/A** | **N/A** | [![][win-arm-badge-3.1.3XX]][win-arm-version-3.1.3XX]<br>[zip][win-arm-zip-3.1.3XX] - [Checksum][win-arm-zip-checksum-3.1.3XX] | [![][win-arm-badge-3.1.2XX]][win-arm-version-3.1.2XX]<br>[zip][win-arm-zip-3.1.2XX] - [Checksum][win-arm-zip-checksum-3.1.2XX] | [![][win-arm-badge-3.1.1XX]][win-arm-version-3.1.1XX]<br>[zip][win-arm-zip-3.1.1XX] - [Checksum][win-arm-zip-checksum-3.1.1XX] | [![][win-arm-badge-3.0.1XX]][win-arm-version-3.0.1XX]<br>[zip][win-arm-zip-3.0.1XX] - [Checksum][win-arm-zip-checksum-3.0.1XX] |
+| **FreeBSD x64** | [![][freebsd-x64-badge-master]][freebsd-x64-version-master]<br>[tar.gz][freebsd-x64-zip-master] - [Checksum][freebsd-x64-zip-checksum-master]  | **N/A** | **N/A** | [![][freebsd-x64-badge-3.1.3XX]][freebsd-x64-version-3.1.3XX]<br>[tar.gz][freebsd-x64-zip-3.1.3XX] - [Checksum][freebsd-x64-zip-checksum-3.1.3XX]  | [![][freebsd-x64-badge-3.1.2XX]][freebsd-x64-version-3.1.2XX]<br>[tar.gz][freebsd-x64-zip-3.1.2XX] - [Checksum][freebsd-x64-zip-checksum-3.1.2XX]  | [![][freebsd-x64-badge-3.1.1XX]][freebsd-x64-version-3.1.1XX]<br>[tar.gz][freebsd-x64-zip-3.1.1XX] - [Checksum][freebsd-x64-zip-checksum-3.1.1XX]  | [![][freebsd-x64-badge-3.0.1XX]][freebsd-x64-version-3.0.1XX]<br>[tar.gz][freebsd-x64-zip-3.0.1XX] - [Checksum][freebsd-x64-zip-checksum-3.0.1XX]  |
+| **Constituent Repo Shas** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | [Git SHAs][sdk-shas-2.2.1XX] |
 
 Reference notes:
 > **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
@@ -71,12 +70,19 @@ Reference notes:
 
 .NET Core SDK 2.x downloads can be found here: [.NET Core SDK 2.x Installers and Binaries](Downloads2.x.md)
 
-[win-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/win_x64_Release_version_badge.svg
+[win-x64-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/win_x64_Release_version_badge.svg
 [win-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[win-x64-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.exe
-[win-x64-installer-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.exe.sha
-[win-x64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.zip
-[win-x64-zip-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.zip.sha
+[win-x64-installer-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x64.zip.sha
+
+[win-x64-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/win_x64_Release_version_badge.svg
+[win-x64-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[win-x64-installer-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x64.zip.sha
 
 [win-x64-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/win_x64_Release_version_badge.svg
 [win-x64-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -113,12 +119,19 @@ Reference notes:
 [win-x64-zip-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x64.zip
 [win-x64-zip-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x64.zip.sha
 
-[win-x86-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/win_x86_Release_version_badge.svg
+[win-x86-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/win_x86_Release_version_badge.svg
 [win-x86-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[win-x86-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x86.exe
-[win-x86-installer-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x86.exe.sha
-[win-x86-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x86.zip
-[win-x86-zip-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x86.zip.sha
+[win-x86-installer-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-x86.zip.sha
+
+[win-x86-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/win_x86_Release_version_badge.svg
+[win-x86-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[win-x86-installer-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-win-x86.zip.sha
 
 [win-x86-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/win_x86_Release_version_badge.svg
 [win-x86-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -155,12 +168,19 @@ Reference notes:
 [win-x86-zip-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x86.zip
 [win-x86-zip-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x86.zip.sha
 
-[osx-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/osx_x64_Release_version_badge.svg
+[osx-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/osx_x64_Release_version_badge.svg
 [osx-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[osx-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-osx-x64.pkg
-[osx-installer-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-osx-x64.pkg.sha
-[osx-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-osx-x64.tar.gz
-[osx-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-osx-x64.tar.gz.sha
+[osx-installer-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-osx-x64.pkg
+[osx-installer-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-osx-x64.pkg.sha
+[osx-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-osx-x64.tar.gz
+[osx-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+
+[osx-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/osx_x64_Release_version_badge.svg
+[osx-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[osx-installer-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-osx-x64.pkg
+[osx-installer-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-osx-x64.pkg.sha
+[osx-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-osx-x64.tar.gz
+[osx-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
 [osx-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/osx_x64_Release_version_badge.svg
 [osx-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -197,14 +217,23 @@ Reference notes:
 [osx-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-osx-x64.tar.gz
 [osx-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
 
-[linux-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/linux_x64_Release_version_badge.svg
+[linux-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/linux_x64_Release_version_badge.svg
 [linux-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[linux-DEB-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-x64.deb
-[linux-DEB-installer-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-x64.deb.sha
-[linux-RPM-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-x64.rpm
-[linux-RPM-installer-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-x64.rpm.sha
-[linux-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-x64.tar.gz
-[linux-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-x64.tar.gz.sha
+[linux-DEB-installer-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-x64.rpm.sha
+[linux-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-x64.tar.gz.sha
+
+[linux-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/linux_x64_Release_version_badge.svg
+[linux-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[linux-DEB-installer-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-x64.rpm.sha
+[linux-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-x64.tar.gz.sha
 
 [linux-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/linux_x64_Release_version_badge.svg
 [linux-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -251,10 +280,15 @@ Reference notes:
 [linux-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-x64.tar.gz
 [linux-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-x64.tar.gz.sha
 
-[linux-arm-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/linux_arm_Release_version_badge.svg
+[linux-arm-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/linux_arm_Release_version_badge.svg
 [linux-arm-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[linux-arm-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm.tar.gz
-[linux-arm-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm.tar.gz.sha
+[linux-arm-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-arm.tar.gz.sha
+
+[linux-arm-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/linux_arm_Release_version_badge.svg
+[linux-arm-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[linux-arm-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-arm.tar.gz.sha
 
 [linux-arm-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/linux_arm_Release_version_badge.svg
 [linux-arm-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -281,10 +315,15 @@ Reference notes:
 [linux-arm-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-arm.tar.gz
 [linux-arm-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-arm.tar.gz.sha
 
-[linux-arm64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/linux_arm64_Release_version_badge.svg
+[linux-arm64-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/linux_arm64_Release_version_badge.svg
 [linux-arm64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[linux-arm64-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-arm64.tar.gz.sha
+[linux-arm64-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-arm64.tar.gz.sha
+
+[linux-arm64-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[linux-arm64-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-arm64.tar.gz.sha
 
 [linux-arm64-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/linux_arm64_Release_version_badge.svg
 [linux-arm64-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -311,10 +350,15 @@ Reference notes:
 [linux-arm64-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-arm64.tar.gz.sha
 
-[rhel-6-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/rhel.6_x64_Release_version_badge.svg
+[rhel-6-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/rhel.6_x64_Release_version_badge.svg
 [rhel-6-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[rhel-6-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
+[rhel-6-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-rhel.6-x64.tar.gz.sha
+
+[rhel-6-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[rhel-6-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
 [rhel-6-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/rhel.6_x64_Release_version_badge.svg
 [rhel-6-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -341,10 +385,15 @@ Reference notes:
 [rhel-6-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
 
-[linux-musl-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/linux_musl_x64_Release_version_badge.svg
+[linux-musl-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/linux_musl_x64_Release_version_badge.svg
 [linux-musl-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[linux-musl-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-musl-x64.tar.gz
-[linux-musl-targz-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
+[linux-musl-targz-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-targz-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-linux-musl-x64.tar.gz.sha
+
+[linux-musl-badge-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/linux_musl_x64_Release_version_badge.svg
+[linux-musl-version-5.0.1XX-preview2]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview2/latest.version
+[linux-musl-targz-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-targz-checksum-5.0.1XX-preview2]: https://aka.ms/dotnet/net5/preview2/Sdk/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
 [linux-musl-badge-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/linux_musl_x64_Release_version_badge.svg
 [linux-musl-version-5.0.1XX-preview1]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/5.0.1xx-preview1/latest.version
@@ -371,10 +420,10 @@ Reference notes:
 [linux-musl-targz-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-musl-x64.tar.gz
 [linux-musl-targz-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
 
-[win-arm-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/win_arm_Release_version_badge.svg
+[win-arm-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/win_arm_Release_version_badge.svg
 [win-arm-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[win-arm-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-arm.zip
-[win-arm-zip-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-arm.zip.sha
+[win-arm-zip-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-win-arm.zip.sha
 
 [win-arm-badge-3.1.3XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.3xx/win_arm_Release_version_badge.svg
 [win-arm-version-3.1.3XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.3xx/latest.version
@@ -396,14 +445,10 @@ Reference notes:
 [win-arm-zip-3.0.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-arm.zip
 [win-arm-zip-checksum-3.0.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-arm.zip.sha
 
-[win-arm-64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/win_arm64_Release_version_badge.svg
-[win-arm-64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[win-arm-64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-arm64.zip
-
-[freebsd-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/freebsd_x64_Release_version_badge.svg
+[freebsd-x64-badge-master]: https://aka.ms/dotnet/net5/dev/Sdk/freebsd_x64_Release_version_badge.svg
 [freebsd-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
-[freebsd-x64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-freebsd-x64.tar.gz
-[freebsd-x64-zip-checksum-master]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-freebsd-x64.tar.gz.sha
+[freebsd-x64-zip-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-freebsd-x64.tar.gz
+[freebsd-x64-zip-checksum-master]: https://aka.ms/dotnet/net5/dev/Sdk/dotnet-sdk-freebsd-x64.tar.gz.sha
 
 [freebsd-x64-badge-3.1.3XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.3xx/freebsd_x64_Release_version_badge.svg
 [freebsd-x64-version-3.1.3XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.3xx/latest.version


### PR DESCRIPTION
Added download links for 5.0.100 preview 2.

Links are replaced with "aka.ms" ones on 5.0 branches for:
- Badges
- Installers, zip and tar.gz files
- Checksums (doesn't work because of https://github.com/dotnet/sdk/issues/10892)

Links that are not yet replaced with aka.ms ones on 5.0 branches:
- latest.version (WIP)

skipciplease
skip ci please (what is the proper way of doing this?)
